### PR TITLE
Import pandy field changes: web_view launch, AIS topic/launch fixes, coverage footprint outline

### DIFF
--- a/marine_web_view/README.md
+++ b/marine_web_view/README.md
@@ -424,7 +424,7 @@ ros2 launch marine_web_view web_view_launch.py enable_ais:=false
 | `platform` | `bizzy` | Drives the five derived values below; each stays individually overridable |
 | `platform_name` | `platform` | Must equal `PlatformList.platform_namespace` or `.name` — see below |
 | `platforms_topic` | `/marine/platforms` | Global, so not derived from `platform` |
-| `contacts_topic` | `/<platform>/ais/contacts` | BizzyBoat carries its own receiver; see below |
+| `contacts_topic` | `/ais/contacts` | Global, not derived — the station receives AIS itself; see below |
 | `coverage_namespace` | `/<platform>/sensors/m3/cube_bathymetry` | |
 | `map_frame` / `chart_datum_frame` | `<platform>/map`, `<platform>/chart_datum` | |
 | `bucket` / `profile` | `unh-ccom-p11-live` / `p11-renderer` | Shared by all three |
@@ -444,11 +444,14 @@ platform's nav topics nor replaces the fallback hull — which is BEN's
 The result is an oversized hull sitting still, with nothing logged as wrong.
 Deriving it from `platform` is what keeps it from being a thing to remember.
 
-**The AIS topic is namespaced here.** The shore-station arrangement the
-`ais_renderer` section describes puts contacts on a global `/ais/contacts`;
-BizzyBoat carries its own receiver and publishes `/bizzy/ais/contacts`. When
-the ROC desktop runs the renderer instead, pass `enable_ais:=false` here and
-launch `ais_renderer_launch.py` there on its own default.
+**The AIS topic is not derived from `platform`.** Both arrangements are
+real: the operator station runs its own `nmea_relay` → `ais_parser` →
+`ais_contact_tracker` chain on the global `/ais/contacts`, while a boat
+carrying its own receiver publishes under its namespace — BizzyBoat's recorded
+bags carry `/bizzy/ais/contacts`. This file is for the station, so the global
+topic is the default; pass `contacts_topic:=/<platform>/ais/contacts` to read
+a boat-side receiver instead. When the ROC desktop runs the renderer, pass
+`enable_ais:=false` here and launch `ais_renderer_launch.py` there.
 
 **Coverage needs the boat up.** The ADR-0008 triple is request/response — the
 renderer publishes `TileRequest` and waits for a live producer — and it is

--- a/marine_web_view/README.md
+++ b/marine_web_view/README.md
@@ -402,6 +402,59 @@ ros2 launch marine_simulation sim_robot_launch.py \
     namespace:=ben platform:=bizzy enable_bridge:=false
 ```
 
+
+### All three at once, live
+
+`web_view_launch.py` brings up all three renderers against one platform and
+publishes to S3. It exists for the deployment where they share a machine — one
+operator station on the live bridge link — and its `platform` argument
+re-points every namespace and frame the per-node files default to BEN:
+
+```bash
+# BizzyBoat, live, to the bucket. This is the whole command.
+ros2 launch marine_web_view web_view_launch.py
+
+# Another boat, or a partial bring-up when the receiver is ashore.
+ros2 launch marine_web_view web_view_launch.py platform:=ben
+ros2 launch marine_web_view web_view_launch.py enable_ais:=false
+```
+
+| Argument | Default | Notes |
+|---|---|---|
+| `platform` | `bizzy` | Drives the five derived values below; each stays individually overridable |
+| `platform_name` | `platform` | Must equal `PlatformList.platform_namespace` or `.name` — see below |
+| `platforms_topic` | `/marine/platforms` | Global, so not derived from `platform` |
+| `contacts_topic` | `/<platform>/ais/contacts` | BizzyBoat carries its own receiver; see below |
+| `coverage_namespace` | `/<platform>/sensors/m3/cube_bathymetry` | |
+| `map_frame` / `chart_datum_frame` | `<platform>/map`, `<platform>/chart_datum` | |
+| `bucket` / `profile` | `unh-ccom-p11-live` / `p11-renderer` | Shared by all three |
+| `dry_run` | `false` | The live run is the point; exposed to exercise the wiring without spending PUTs |
+| `enable_state` / `enable_coverage` / `enable_ais` | `true` | |
+
+Each `key` and `local_path` stays the owning renderer's own — the includes are
+scoped, because the three files declare overlapping argument names and launch
+does not overwrite a configuration that is already set. Unscoped, the AIS
+renderer inherits `state_renderer`'s `key` and PUTs its contacts over
+`live/position.geojson`.
+
+**`platform_name` is the one that fails silently.** `state_renderer` adopts a
+platform only on a name match, and unmatched it neither subscribes to that
+platform's nav topics nor replaces the fallback hull — which is BEN's
+4.25 × 1.70 m, against BizzyBoat's 2.40 × 0.90 m as `PlatformList` reports it.
+The result is an oversized hull sitting still, with nothing logged as wrong.
+Deriving it from `platform` is what keeps it from being a thing to remember.
+
+**The AIS topic is namespaced here.** The shore-station arrangement the
+`ais_renderer` section describes puts contacts on a global `/ais/contacts`;
+BizzyBoat carries its own receiver and publishes `/bizzy/ais/contacts`. When
+the ROC desktop runs the renderer instead, pass `enable_ais:=false` here and
+launch `ais_renderer_launch.py` there on its own default.
+
+**Coverage needs the boat up.** The ADR-0008 triple is request/response — the
+renderer publishes `TileRequest` and waits for a live producer — and it is
+recorded in no bag, so off-boat it renders nothing however long it runs.
+`enable_coverage:=false` is the honest setting then.
+
 ## `web/index.html`
 
 Single-page Leaflet view. Layers, bottom to top: Esri World Imagery, CCOM/JHC

--- a/marine_web_view/launch/ais_renderer_launch.py
+++ b/marine_web_view/launch/ais_renderer_launch.py
@@ -30,6 +30,8 @@
 
 """Launch the public web-view AIS renderer."""
 
+from typing import List
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -112,10 +114,15 @@ def generate_launch_description():
             'heading_variance_threshold': LaunchConfiguration(
                 'heading_variance_threshold'),
             # An INTEGER_ARRAY, so the substitution has to be typed: a bare
-            # LaunchConfiguration reaches the node as the STRING '[]' and the
-            # declared type rejects it at startup.
+            # LaunchConfiguration reaches the node as the STRING '[]', and
+            # `_ignore_list` refuses a string rather than silently ignoring
+            # nobody. The type has to be `List[int]` and not a bare `list`:
+            # launch_ros coerces against int/bool/float/str and their
+            # typing.List forms only, and rejects anything else with
+            # "Unrecognized data type" before a node is spawned -- which took
+            # this launch file down whatever the argument was set to.
             'ignore_mmsis': ParameterValue(
-                LaunchConfiguration('ignore_mmsis'), value_type=list),
+                LaunchConfiguration('ignore_mmsis'), value_type=List[int]),
         }],
     )
 

--- a/marine_web_view/launch/web_view_launch.py
+++ b/marine_web_view/launch/web_view_launch.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Roland Arsenault
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Roland Arsenault nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Launch all three public web-view renderers against one live platform.
+
+The three renderers are separate nodes on purpose -- they have different
+sources and, in the general case, run on different machines. This brings them
+up together for the deployment where they do not: one operator station, live
+on the bridge link, publishing to S3.
+
+Everything the per-node launch files default is BEN's. This file's `platform`
+argument re-points all of it at one boat, so a BizzyBoat run is
+`ros2 launch marine_web_view web_view_launch.py` and not four namespace
+overrides remembered correctly under way. The per-node launch files remain the
+documented path for local preview (`dry_run:=true`) and for the split
+deployment where the AIS receiver is ashore.
+
+`platform_name` is the one that fails silently. `state_renderer` adopts a
+platform only when the name matches `PlatformList.platform_namespace` or
+`.name`; unmatched, it never subscribes to that platform's nav topics and
+keeps the fallback hull. The fallback is BEN's 4.25 x 1.70 m and BizzyBoat is
+2.40 x 0.90 m, so the failure draws a hull nearly twice its true size over a
+boat that never moves, with nothing logged as wrong. Deriving it from
+`platform` here is what keeps that from being a thing to remember.
+
+Coverage has no offline mode. The ADR-0008 triple is a request/response
+protocol -- the renderer publishes TileRequest and waits for a live producer
+to answer -- and it is not recorded in any bag, so `enable_coverage:=false` is
+the honest setting whenever the boat is not up.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def _renderer(launch_file, enable_argument, launch_arguments):
+    """Include one renderer's launch file, gated on its enable argument.
+
+    Scoped, and that is load-bearing rather than tidiness. The three included
+    files declare overlapping argument names -- `interval`, `key`,
+    `local_path` -- with per-renderer defaults, and `DeclareLaunchArgument`
+    does not overwrite a configuration that is already set. Unscoped, the
+    first include to declare a name wins it for every later sibling: the AIS
+    renderer inherits `state_renderer`'s 1 s interval and, worse, its
+    `key` -- so it would PUT its contact collection over
+    `live/position.geojson` and take the boat off its own map. A scope per
+    include keeps each file's defaults its own; the shared values below are
+    the ones passed in deliberately.
+    """
+    return GroupAction(
+        actions=[IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(PathJoinSubstitution([
+                FindPackageShare('marine_web_view'), 'launch', launch_file])),
+            # Only arguments the included file DECLARES may be passed: launch
+            # raises on an unknown one. Anything not listed keeps that
+            # renderer's own default, which is the intent for the S3 keys --
+            # they differ per renderer and are already right.
+            launch_arguments=launch_arguments.items(),
+        )],
+        condition=IfCondition(LaunchConfiguration(enable_argument)),
+        scoped=True,
+        forwarding=True,
+    )
+
+
+def generate_launch_description():
+    """Build the launch description."""
+    platform = LaunchConfiguration('platform')
+    bucket = LaunchConfiguration('bucket')
+    profile = LaunchConfiguration('profile')
+    dry_run = LaunchConfiguration('dry_run')
+
+    args = [
+        DeclareLaunchArgument(
+            'platform', default_value='bizzy',
+            description='Platform to follow. Drives platform_name, the AIS '
+                        'and coverage namespaces, and the two TF frames '
+                        'below, each of which stays individually '
+                        'overridable.'),
+
+        # --- shared AWS destination -------------------------------------
+        DeclareLaunchArgument(
+            'bucket', default_value='unh-ccom-p11-live',
+            description='S3 bucket all three renderers publish to.'),
+        DeclareLaunchArgument(
+            'profile', default_value='p11-renderer',
+            description='AWS profile; scoped to s3:PutObject on live/*.'),
+        DeclareLaunchArgument(
+            'dry_run', default_value='false',
+            description='Write to each renderer local path instead of S3. '
+                        'False is the point of this file -- it exists for the '
+                        'live run. Exposed so the wiring can be exercised '
+                        'without spending PUTs.'),
+
+        # --- per-renderer enables ---------------------------------------
+        DeclareLaunchArgument(
+            'enable_state', default_value='true',
+            description='Run state_renderer (position + track + basemap).'),
+        DeclareLaunchArgument(
+            'enable_coverage', default_value='true',
+            description='Run coverage_renderer. Needs a LIVE producer: the '
+                        'ADR-0008 tile protocol is request/response and is in '
+                        'no bag, so this renders nothing off-boat.'),
+        DeclareLaunchArgument(
+            'enable_ais', default_value='true',
+            description='Run ais_renderer. Set false when the receiver is '
+                        'ashore and the ROC desktop runs it instead.'),
+
+        # --- derived from platform, individually overridable -------------
+        DeclareLaunchArgument(
+            'platform_name', default_value=platform,
+            description='Must equal PlatformList platform_namespace or name, '
+                        'or state_renderer silently keeps the fallback hull '
+                        'and subscribes to nothing.'),
+        DeclareLaunchArgument(
+            'platforms_topic', default_value='/marine/platforms',
+            description='PlatformList topic. Global, not under the platform '
+                        'namespace, so it is not derived from platform.'),
+        DeclareLaunchArgument(
+            'contacts_topic',
+            default_value=['/', platform, '/ais/contacts'],
+            description='AISContact topic. BizzyBoat carries its own '
+                        'receiver, so this is namespaced -- unlike the shore '
+                        'station README default.'),
+        DeclareLaunchArgument(
+            'coverage_namespace',
+            default_value=['/', platform, '/sensors/m3/cube_bathymetry'],
+            description='Namespace carrying the ADR-0008 coverage triple.'),
+        DeclareLaunchArgument(
+            'map_frame', default_value=[platform, '/map'],
+            description='Frame the depth band z values are expressed in.'),
+        DeclareLaunchArgument(
+            'chart_datum_frame', default_value=[platform, '/chart_datum'],
+            description='Vertical reference to colour depths against.'),
+    ]
+
+    renderers = [
+        _renderer('state_renderer_launch.py', 'enable_state', {
+            'platform_name': LaunchConfiguration('platform_name'),
+            'platforms_topic': LaunchConfiguration('platforms_topic'),
+            'bucket': bucket,
+            'profile': profile,
+            'dry_run': dry_run,
+        }),
+        _renderer('coverage_renderer_launch.py', 'enable_coverage', {
+            'coverage_namespace': LaunchConfiguration('coverage_namespace'),
+            'map_frame': LaunchConfiguration('map_frame'),
+            'chart_datum_frame': LaunchConfiguration('chart_datum_frame'),
+            'bucket': bucket,
+            'profile': profile,
+            'dry_run': dry_run,
+        }),
+        _renderer('ais_renderer_launch.py', 'enable_ais', {
+            'contacts_topic': LaunchConfiguration('contacts_topic'),
+            'bucket': bucket,
+            'profile': profile,
+            'dry_run': dry_run,
+        }),
+    ]
+
+    return LaunchDescription(args + renderers)

--- a/marine_web_view/launch/web_view_launch.py
+++ b/marine_web_view/launch/web_view_launch.py
@@ -86,10 +86,13 @@ def _renderer(launch_file, enable_argument, launch_arguments):
         actions=[IncludeLaunchDescription(
             PythonLaunchDescriptionSource(PathJoinSubstitution([
                 FindPackageShare('marine_web_view'), 'launch', launch_file])),
-            # Only arguments the included file DECLARES may be passed: launch
-            # raises on an unknown one. Anything not listed keeps that
-            # renderer's own default, which is the intent for the S3 keys --
-            # they differ per renderer and are already right.
+            # Only arguments the included file DECLARES are worth passing,
+            # and launch does NOT enforce that: an unrecognised name is set
+            # as a plain launch configuration and the node never sees it, so
+            # a typo here is silent. test_web_view_launch.py checks the list
+            # against what each include declares. Anything not listed keeps
+            # that renderer's own default, which is the intent for the S3
+            # keys -- they differ per renderer and are already right.
             launch_arguments=launch_arguments.items(),
         )],
         condition=IfCondition(LaunchConfiguration(enable_argument)),

--- a/marine_web_view/launch/web_view_launch.py
+++ b/marine_web_view/launch/web_view_launch.py
@@ -152,11 +152,12 @@ def generate_launch_description():
             description='PlatformList topic. Global, not under the platform '
                         'namespace, so it is not derived from platform.'),
         DeclareLaunchArgument(
-            'contacts_topic',
-            default_value=['/', platform, '/ais/contacts'],
-            description='AISContact topic. BizzyBoat carries its own '
-                        'receiver, so this is namespaced -- unlike the shore '
-                        'station README default.'),
+            'contacts_topic', default_value='/ais/contacts',
+            description='AISContact topic. Global, NOT derived from '
+                        'platform: this file is for the operator station, '
+                        'and the station receives AIS itself. Pass '
+                        '/<platform>/ais/contacts to read a boat-side '
+                        'receiver instead.'),
         DeclareLaunchArgument(
             'coverage_namespace',
             default_value=['/', platform, '/sensors/m3/cube_bathymetry'],

--- a/marine_web_view/test/test_page_layers.py
+++ b/marine_web_view/test/test_page_layers.py
@@ -910,3 +910,37 @@ def test_the_construction_pattern_tracks_the_pages_layer_classes():
         'a newly defined layer class is not discovered')
     assert re.search(_constructions(invented), 'x = new Sidescan({});'), (
         'a newly defined layer class would escape the addTo check')
+
+
+def test_the_coverage_outline_is_wired_end_to_end():
+    """Dropping any one of the outline's three pieces silently removes it.
+
+    Coverage shares the basemap's depth ramp on purpose (#345 -- one depth
+    must not read as two colours), so where new soundings agree with the
+    chart the surveyed area has no edge of its own. The outline is what
+    puts one back, and it only works as a chain: a pane is created, the
+    coverage layer is built INTO that pane, and a stylesheet rule filters
+    the pane as a whole.
+
+    Break any link and nothing errors. The page loads, the tiles paint, the
+    coverage is still there -- and the operator simply cannot see where the
+    survey ends, which is the exact condition the outline was added to fix.
+    Drop `pane: 'coverage'` and the filter applies to an empty pane; drop
+    the rule and the pane is unstyled; drop the pane and Leaflet throws only
+    at layer-construction time, inside a rebuild that happens on every
+    manifest zoom change rather than at page load.
+    """
+    page = _page()
+
+    assert re.search(r"createPane\s*\(\s*'coverage'\s*\)", page), (
+        'the coverage pane is no longer created -- the outline filter has '
+        'nothing to apply to')
+
+    assert re.search(r"pane\s*:\s*'coverage'", page), (
+        'the coverage layer no longer renders into the coverage pane, so '
+        'the outline filter applies to an empty pane and the surveyed area '
+        'loses its edge against the basemap ramp (#345)')
+
+    assert re.search(r'\.leaflet-coverage-pane\s*\{[^}]*drop-shadow', page), (
+        'the .leaflet-coverage-pane drop-shadow rule is gone -- coverage '
+        'reverts to being the same colour as the seabed beneath it')

--- a/marine_web_view/test/test_web_view_launch.py
+++ b/marine_web_view/test/test_web_view_launch.py
@@ -57,8 +57,11 @@ from launch_ros.actions import Node
 
 PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# The renderers, in the order web_view_launch.py includes them, with the S3
-# key each one must end up owning. Sharing a key is the failure this file
+# The two renderers that own an S3 key, in the order web_view_launch.py
+# includes them, with the key and interval each must end up with.
+# coverage_renderer is deliberately absent: it declares neither argument,
+# because it publishes a tile tree rather than one object. The uniqueness
+# check below still covers all three. Sharing a key is the failure this file
 # exists for, so the expected values are written out rather than derived.
 EXPECTED = (
     ('state_renderer', 'live/position.geojson', '1.0'),

--- a/marine_web_view/test/test_web_view_launch.py
+++ b/marine_web_view/test/test_web_view_launch.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Roland Arsenault
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Roland Arsenault nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Guard the wiring `web_view_launch.py` does on behalf of three renderers.
+
+This file brings up `state_renderer`, `coverage_renderer` and `ais_renderer`
+together, and every failure it can introduce is a SILENT one: the launch
+succeeds, three nodes come up, and the artifacts are wrong. Nothing raises,
+so nothing but a test will say so.
+
+Unlike `test_launch_params.py`, which reads the launch files as text, these
+tests EVALUATE the launch description -- visiting the includes and resolving
+the substitutions -- because the failures below live in what the arguments
+resolve TO inside each include, which no amount of grepping can see. The
+launch-time crash fixed in `d3b1642` (`ParameterValue` rejecting a bare
+`list` as `value_type`) was this same class: invisible to static reading,
+immediate on evaluation.
+"""
+
+import importlib.util
+import os
+
+from launch import LaunchContext
+from launch.substitutions import TextSubstitution
+from launch.utilities import normalize_to_list_of_substitutions
+from launch.utilities import perform_substitutions
+
+from launch_ros.actions import Node
+
+PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The renderers, in the order web_view_launch.py includes them, with the S3
+# key each one must end up owning. Sharing a key is the failure this file
+# exists for, so the expected values are written out rather than derived.
+EXPECTED = (
+    ('state_renderer', 'live/position.geojson', '1.0'),
+    ('ais_renderer', 'live/ais.geojson', '10.0'),
+)
+
+
+def _load_launch_module():
+    """Import web_view_launch.py from the source tree under test.
+
+    `FindPackageShare` is replaced with the source package root. Left alone
+    it resolves through the ament index to the INSTALLED share directory,
+    which is a different copy of these launch files -- so the test would pass
+    or fail on whatever happens to be built rather than on the tree it is
+    checking. Substituting the root keeps it hermetic.
+    """
+    path = os.path.join(PACKAGE_ROOT, 'launch', 'web_view_launch.py')
+    spec = importlib.util.spec_from_file_location('web_view_launch', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.FindPackageShare = lambda package: TextSubstitution(
+        text=PACKAGE_ROOT)
+    return module
+
+
+def _resolve(**overrides):
+    """Evaluate the launch description; return one config dict per node.
+
+    Returns the launch configurations visible AT each `Node`, in include
+    order, which is what the node actually receives. Reading them at the top
+    level instead would miss the whole point: the scoping this file checks is
+    precisely what makes those two different.
+    """
+    module = _load_launch_module()
+    context = LaunchContext()
+    for name, value in overrides.items():
+        context.launch_configurations[name] = value
+    resolved = []
+
+    def walk(entities):
+        for entity in entities:
+            if isinstance(entity, Node):
+                resolved.append(dict(context.launch_configurations))
+                continue
+            sub_entities = entity.visit(context)
+            if sub_entities:
+                walk(sub_entities)
+
+    walk(module.generate_launch_description().entities)
+    return resolved
+
+
+def test_each_renderer_keeps_its_own_destination():
+    """The scoping guard, and the most expensive failure in the file.
+
+    The three included files declare overlapping argument names -- `key`,
+    `interval`, `local_path` -- with per-renderer defaults, and
+    `DeclareLaunchArgument` does not overwrite a configuration already set.
+    Without `scoped=True` on each include, the first one to declare a name
+    wins it for every later sibling, and `ais_renderer` inherits
+    `state_renderer`'s key: it PUTs its contact collection over
+    `live/position.geojson` and takes the boat off its own map, at
+    state_renderer's 1 s interval rather than its own 10 s.
+
+    Nothing about that is visible at launch. The nodes start, the PUTs
+    succeed, and the page simply stops showing the vessel.
+    """
+    resolved = _resolve()
+    assert len(resolved) == 3, (
+        'expected three renderers, resolved {} -- if a renderer was added or '
+        'removed, update EXPECTED rather than loosening this'
+        .format(len(resolved)))
+
+    keys = [config.get('key') for config in resolved if config.get('key')]
+    assert len(set(keys)) == len(keys), (
+        'two renderers resolved to the same S3 key ({}) -- one is '
+        'overwriting the other. Check that every include in '
+        'web_view_launch.py is still scoped=True'.format(sorted(keys)))
+
+    by_key = {config.get('key'): config for config in resolved}
+    for renderer, key, interval in EXPECTED:
+        assert key in by_key, (
+            '{} did not resolve to its own key {} -- got {}'
+            .format(renderer, key, sorted(by_key)))
+        assert by_key[key].get('interval') == interval, (
+            '{} resolved to interval {} rather than its own {} -- a sibling '
+            "include's default has leaked into it"
+            .format(renderer, by_key[key].get('interval'), interval))
+
+
+def test_every_argument_passed_to_an_include_is_declared_there():
+    """An argument the include does not declare is silently dropped.
+
+    `IncludeLaunchDescription` sets an unrecognised argument as a plain
+    launch configuration rather than raising -- its own documentation says
+    so, because it cannot reliably detect every `DeclareLaunchArgument` in
+    the included description. So a renamed or mistyped argument here does not
+    fail: the node keeps its default, the override does nothing, and the
+    result is the drift `test_launch_params.py` was written for after #341.
+
+    That file checks each launch file against its own node. This checks the
+    direction it cannot see -- across the include boundary.
+    """
+    module = _load_launch_module()
+    context = LaunchContext()
+    checked = 0
+
+    def walk(entities):
+        nonlocal checked
+        for entity in entities:
+            if isinstance(entity, Node):
+                continue
+            # Read the arguments BEFORE visiting and the source location
+            # after: the location is a substitution until the include
+            # resolves it.
+            passed = getattr(entity, 'launch_arguments', None)
+            sub_entities = entity.visit(context)
+            if passed:
+                source = entity.launch_description_source
+                declared = {
+                    argument.name for argument
+                    in source.get_launch_description(context)
+                    .get_launch_arguments()}
+                names = {
+                    perform_substitutions(
+                        context, normalize_to_list_of_substitutions(name))
+                    for name, _ in passed}
+                unknown = names - declared
+                assert not unknown, (
+                    'web_view_launch.py passes {} to {}, which does not '
+                    'declare it -- the value is silently ignored and the '
+                    'renderer keeps its own default'
+                    .format(sorted(unknown), os.path.basename(source.location)))
+                checked += 1
+            if sub_entities:
+                walk(sub_entities)
+
+    walk(module.generate_launch_description().entities)
+    assert checked == 3, (
+        'expected to check three includes, saw {} -- this guard would pass '
+        'vacuously; update it rather than removing it'.format(checked))
+
+
+def test_the_ais_contacts_topic_is_not_derived_from_the_platform():
+    """The field regression fixed in `22046b7`, pinned.
+
+    Derived from `platform`, `contacts_topic` became `/bizzy/ais/contacts`.
+    That topic is real, but boat-side -- it is what the bags carry, because
+    BizzyBoat has its own receiver. This file is for the OPERATOR STATION,
+    which runs its own nmea_relay -> ais_parser -> ais_contact_tracker chain
+    on the global `/ais/contacts`.
+
+    Subscribed to a topic that does not exist there, the renderer published
+    an empty collection forever, and the page read as a quiet river rather
+    than as a misconfiguration. Deriving it again would restore exactly that.
+    """
+    resolved = _resolve()
+    topics = {config.get('contacts_topic') for config in resolved}
+    assert '/ais/contacts' in topics, (
+        'the AIS renderer no longer defaults to the station receiver on '
+        '/ais/contacts -- got {}'.format(sorted(t for t in topics if t)))
+    for platform in ('bizzy', 'izzy', 'ben'):
+        resolved = _resolve(platform=platform)
+        topics = {config.get('contacts_topic') for config in resolved}
+        assert '/{}/ais/contacts'.format(platform) not in topics, (
+            'contacts_topic is derived from platform again; the operator '
+            'station does not carry /{}/ais/contacts and the renderer would '
+            'publish an empty collection forever'.format(platform))
+
+
+def test_platform_name_follows_the_platform():
+    """`platform_name` must track `platform`, or the hull is silently wrong.
+
+    `state_renderer` adopts a platform only when the name matches
+    `PlatformList.platform_namespace` or `.name`. Unmatched, it subscribes to
+    nothing and keeps the fallback hull -- BEN's 4.25 x 1.70 m over
+    BizzyBoat's 2.40 x 0.90 m. The page then draws a hull nearly twice its
+    true size over a boat that never moves, and nothing is logged as wrong.
+    """
+    for platform in ('bizzy', 'izzy', 'ben'):
+        resolved = _resolve(platform=platform)
+        names = {config.get('platform_name') for config in resolved}
+        assert platform in names, (
+            'platform:={} did not reach platform_name (got {}) -- '
+            'state_renderer would keep the fallback hull'
+            .format(platform, sorted(n for n in names if n)))
+
+
+def test_each_renderer_can_be_disabled_on_its_own():
+    """The enable gates must gate, and gate only their own renderer.
+
+    `enable_coverage:=false` is the honest setting whenever the boat is not
+    up -- the ADR-0008 tile protocol is request/response and is in no bag, so
+    coverage renders nothing off-boat. A gate that silently did nothing would
+    leave a node polling for a producer that cannot answer.
+    """
+    assert len(_resolve()) == 3
+    for argument in ('enable_state', 'enable_coverage', 'enable_ais'):
+        resolved = _resolve(**{argument: 'false'})
+        assert len(resolved) == 2, (
+            '{}:=false left {} renderers running rather than 2'
+            .format(argument, len(resolved)))

--- a/marine_web_view/web/index.html
+++ b/marine_web_view/web/index.html
@@ -101,6 +101,25 @@
     .lgticks { flex-direction:row; justify-content:space-between; width:100%; }
     #hud.collapsed #details, #hud.collapsed .sub { display:none; }
   }
+
+  /* Outline the live-coverage footprint. Coverage deliberately shares the
+     basemap's depth ramp (uma#345), so where new soundings agree with the
+     chart it is the same colour as the seabed under it and the surveyed area
+     has no visible edge. drop-shadow follows the ALPHA channel, and a coverage
+     tile is transparent wherever the sonar has not covered ground, so this
+     traces the true survey boundary rather than a bounding box.
+
+     On the pane, so the tiles composite into one image before the filter runs.
+     Per-tile it would outline all four sides of every tile, seams included.
+
+     Two shadows: a dark one to separate coverage from light seabed colours, and
+     a tight white one inside it so the edge survives against the dark blues at
+     the deep end of the ramp. Kept to 3px/2px -- the footprint should read at a
+     glance without the halo swallowing the thin coverage of a single line. */
+  .leaflet-coverage-pane {
+    filter: drop-shadow(0 0 3px rgba(0,0,0,.85))
+            drop-shadow(0 0 1px rgba(255,255,255,.55));
+  }
 </style>
 </head>
 <body>
@@ -186,6 +205,23 @@ const DEAD_S  = 60;   // red past this
 // zoomed away from its single rendered level.
 const map = L.map('map', { zoomControl: true, minZoom: 8, maxZoom: 22 })
   .setView([43.08, -70.71], 13);
+
+// Live coverage gets a pane of its own so the outline in the stylesheet can be
+// applied to the layer as a WHOLE. Coverage shares the basemap's depth ramp on
+// purpose (uma#345: the ramps must not diverge, or one depth reads as two
+// colours), so the footprint cannot be picked out by colour -- it is picked out
+// by an outline instead, and the outline needs the union of the tiles.
+//
+// A pane, NOT the tile layer: `filter` on the layer shadows each <img>
+// separately, so every interior tile seam gets an edge and the operator reads a
+// grid over live coverage. Compositing the pane first outlines only the real
+// coverage boundary, which is exactly where the tiles turn transparent.
+// Created once here, not per layer -- the coverage layer is torn down and
+// rebuilt on every manifest zoom change.
+map.createPane('coverage');
+// Same stacking the layer's own zIndex option used to set, moved up to the pane
+// so the pane (and its outline) sits above imagery and hillshade as one unit.
+map.getPane('coverage').style.zIndex = 350;
 
 // Basemap: Esri World Imagery -- genuinely cached. NOTE {z}/{y}/{x} (ArcGIS
 // order), reversed from the usual XYZ, and the tiles are JPEG.
@@ -500,7 +536,9 @@ function buildCoverage(zoom) {
     maxZoom: COVERAGE_MAX_Z,
     minNativeZoom: zoom, maxNativeZoom: zoom,
     opacity: coverageAlive ? COVERAGE_OPACITY : COVERAGE_STALE_OPACITY,
-    zIndex: 350,
+    // Stacking now lives on the pane (see createPane above), which is what the
+    // outline filter is applied to.
+    pane: 'coverage',
     // A tile exists only where the sonar has covered ground, so a miss is the
     // normal case rather than an error. Serve a transparent pixel instead of
     // letting Leaflet show a broken-image tile. That is exactly why the

--- a/marine_web_view/web/index.html
+++ b/marine_web_view/web/index.html
@@ -114,7 +114,7 @@
 
      Two shadows: a dark one to separate coverage from light seabed colours, and
      a tight white one inside it so the edge survives against the dark blues at
-     the deep end of the ramp. Kept to 3px/2px -- the footprint should read at a
+     the deep end of the ramp. Kept to 3px/1px -- the footprint should read at a
      glance without the halo swallowing the thin coverage of a single line. */
   .leaflet-coverage-pane {
     filter: drop-shadow(0 0 3px rgba(0,0,0,.85))


### PR DESCRIPTION
Imports four commits made on **pandy** (operator station) during live web-view
operation and pushed to the gitcloud field remote. `gitcloud/jazzy` was a
strict superset of `origin/jazzy`, so these arrive with their **original SHAs**
— no cherry-pick, no rewrite.

Closes #360.

## Commits

| SHA | What |
|---|---|
| `d3b1642` | `fix: ais_renderer_launch could not launch at all` |
| `7441896` | `feat: one launch for all three renderers, live to S3` |
| `22046b7` | `fix: default the AIS topic to the station receiver, not the boat` |
| `ea6bdce` | `feat(web): outline the live-coverage footprint so it reads against the basemap` |

Two are field diagnoses of the AIS bring-up that only surface when it is
actually running:

- `ParameterValue` rejects a bare `list` as `value_type` — it coerces against
  `int`/`bool`/`float`/`str` and their `typing.List` forms only — so
  `ais_renderer_launch.py` raised `Unrecognized data type: <class 'list'>` and
  died before spawning a node, whatever `ignore_mmsis` was set to.
- `contacts_topic` was derived from `platform`, giving `/bizzy/ais/contacts`.
  Real, but **boat-side** — that is what the bags carry, because BizzyBoat has
  its own receiver. The operator station runs its own
  `nmea_relay → ais_parser → ais_contact_tracker` chain on the global
  `/ais/contacts`, which is what the `ais_renderer` README section documented
  all along. Derived, the renderer subscribed to a topic that does not exist
  there and published an empty collection forever, reading on the page as a
  quiet river rather than as a misconfiguration.

`7441896` adds `web_view_launch.py` for the deployment where all three
renderers share one host. Each include is **scoped**, which is load-bearing:
the three files declare overlapping argument names (`interval`, `key`,
`local_path`) and `DeclareLaunchArgument` does not overwrite a configuration
already set, so unscoped the first include wins them for every later sibling —
the AIS renderer would have inherited `state_renderer`'s 1 s interval and key
and PUT its contact collection over `live/position.geojson`. Caught in a dry
run.

`ea6bdce` is the only commit that changes the deployed page. Coverage shares
the basemap depth ramp on purpose (#345, so one depth cannot read as two
colours); the consequence reported from the boat is that where new soundings
agree with the chart, the surveyed area has no visible edge. Fixed by
outlining, not recolouring — recolouring would undo #345. `drop-shadow`
follows the alpha channel and coverage tiles are transparent where the sonar
has not covered ground, so it traces the true survey boundary rather than a
bounding box. The filter sits on a dedicated pane rather than the tile layer,
because per-tile it would outline every tile seam and paint a grid over live
coverage.

## Test plan

- [x] `d3b1642` verified on pandy both ways: default empty list starts clean;
      `ignore_mmsis:="[366000001,367000002]"` logs `never publishing MMSI
      366000001, 367000002`.
- [x] `7441896` scoping caught and fixed in a dry run before it could overwrite
      `live/position.geojson`.
- [x] `22046b7` confirmed live — AIS contacts flowing to `live/ais.geojson`
      from the station receiver.
- [x] `ea6bdce` deployed to the bucket and confirmed rendering through
      CloudFront.
- [x] **Owed, now discharged:** these are field changes, and per the Quality
      Standard field changes are drafts. `web_view_launch.py` now has
      `test_web_view_launch.py` (5 tests: scoping/key ownership, include
      arguments actually declared, the AIS topic not derived from `platform`,
      `platform_name` tracking it, and the enable gates). The pane change is
      guarded in `test_page_layers.py` — verified failing when the pane, the
      `pane: 'coverage'` option, or the CSS rule is removed. Package suite:
      278 passed.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`

