### PR TITLE
Field import: unh_marine_autonomy (2026-08-26..27)

### DIFF
--- a/.agent/work-plans/issue-362/progress.md
+++ b/.agent/work-plans/issue-362/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 362
+---
+
+# Issue #362 — Field import: unh_marine_autonomy (2026-08-26..27)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-09-03 15:04 -04:00
+**By**: Claude Code Agent (Claude Opus 5 (1M context))
+
+**PR**: #363 at `cba4d0c`
+**Sources**: 3 (Copilot R1 @ `a4fafed`, Copilot R2 @ `cba4d0c`, CI rollup)
+**Cross-source confirmations**: 0
+**CI**: all-pass
+
+### Findings
+- [ ] (must-fix, Copilot R2) The PR contradicts itself in operator-facing text: `20f7b0a` wrote "Keep it STRICTLY below render_interval", `a4fafed` (same PR) states that reasoning "could not have worked" and replaced it with URL versioning. Superseded claim still stands in the launch-arg description, visible via `ros2 launch --show-args` — `marine_web_view/launch/web_view_launch.py:183-191`
+- [ ] (must-fix, Copilot R1) A malformed manifest can leave a stale history layer on the map: `buildHistory()` returns false on bad zooms before any teardown, so `!buildHistory(meta) && historyLayer === null` is false when a layer exists, the catch never runs, and the readout updates from the broken manifest. Contradicts the catch block's own stated intent — `marine_web_view/web/index.html:826`
+- [ ] (valid, Copilot R2) Catalog QoS: code is VOLATILE but `README.md:514` documents RELIABLE/TRANSIENT_LOCAL for this topic, and the comment's stated root cause ("the real fix is in the relay") is now known wrong — udp_bridge supports per-topic transient_local; the boat's bridge config never set it (rolker/unh_echoboats_project11#484). Copilot suggested a durability parameter; recommended instead to correct the comment, add the revert condition, and reconcile the README, matching camp#220. Operator decision on shape — `marine_web_view/marine_web_view/coverage_renderer.py:533`
+- [ ] (valid, Copilot R1) `ThreadPoolExecutor(concurrency)` unclamped; `--concurrency 0` aborts with ValueError. Sibling `refresh_chart_tiles.py:771` clamps with `max(1, int(...))`. `--processes` has the same shape, unflagged — `marine_web_view/scripts/publish_history_tiles.py:586`
+- [ ] (minor, Copilot R2) `historyText()` returns "0 days · " with a trailing separator when labels are missing/empty/scrubbed; reachable because `buildHistory` gates on zooms only — `marine_web_view/web/index.html:813`
+- [ ] (minor, Copilot R2) `lock_dir()` lacks the `S_ISDIR` guard its sibling has. Tested: a symlink is currently rejected anyway because its mode is 0o777 and the group/world-writable check trips, so this is defense-in-depth plus a legible error rather than an open hole — `marine_web_view/scripts/publish_history_tiles.py:488`
+
+### False positives
+(none — all six verified against the code; F1 and F6 both correctly cite an in-repo precedent)

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ __pycache__/
 # IDE
 .vscode/
 .idea/
+
+# Local previews. Every dry_run in marine_web_view writes into web/live/ --
+# that is the same relative path the bucket serves, which is what makes the
+# page render identically against a local copy and against CloudFront. The
+# artifacts themselves are generated: geojson from the renderers, and a whole
+# tile pyramid from publish_history_tiles.py.
+marine_web_view/web/live/

--- a/marine_web_view/README.md
+++ b/marine_web_view/README.md
@@ -511,9 +511,20 @@ Part of [#345](https://github.com/rolker/unh_marine_autonomy/issues/345).
 
 | topic | type | QoS | role |
 |---|---|---|---|
-| `<ns>/coverage_catalog` | `marine_interfaces/TileCatalog` | RELIABLE, **TRANSIENT_LOCAL** | complete snapshot of what the source holds |
+| `<ns>/coverage_catalog` | `marine_interfaces/TileCatalog` | RELIABLE, **TRANSIENT_LOCAL** (this renderer currently subscribes VOLATILE — see note below) | complete snapshot of what the source holds |
 | `<ns>/coverage_requests` | `marine_interfaces/TileRequest` | RELIABLE, VOLATILE | what we are missing or stale on |
 | `<ns>/coverage_tiles` | `marine_interfaces/SonarVisualizationTile` | **BEST_EFFORT**, VOLATILE | dirty sub-windows |
+
+> **Durability note — the renderer's subscription does not currently match this table.**
+> `TRANSIENT_LOCAL` above is what `cube_bathymetry` publishes and what this renderer
+> *should* request. It subscribes `VOLATILE` instead, as a field workaround: the
+> operator-side bridge republishes the catalog `VOLATILE`, and a transient-local
+> subscriber cannot match a volatile publisher, so the renderer received no catalog
+> at all. The cause is a missing `durability: transient_local` on the boat's bridge
+> topic entry, not a defect in the relay — tracked with the coupled revert as
+> [rolker/unh_echoboats_project11#484](https://github.com/rolker/unh_echoboats_project11/issues/484).
+> Revert `coverage_renderer.py` to `TRANSIENT_LOCAL` when that lands; nothing will
+> prompt it, because a transient-local publisher still matches a volatile subscriber.
 
 The catalog is a **complete** snapshot, and that completeness is a
 precondition: prune-on-absence against a partial or paged catalog would read

--- a/marine_web_view/README.md
+++ b/marine_web_view/README.md
@@ -461,8 +461,8 @@ recorded in no bag, so off-boat it renders nothing however long it runs.
 ## `web/index.html`
 
 Single-page Leaflet view. Layers, bottom to top: Esri World Imagery, CCOM/JHC
-bathymetry rendered as fixed-scale depth colours, hillshade, live sonar
-coverage, then the vessel track and hull. The vessel is drawn with CAMP's
+bathymetry rendered as fixed-scale depth colours, hillshade, previously
+surveyed days, live sonar coverage, then the vessel track and hull. The vessel is drawn with CAMP's
 geometry — triangle while metres-per-pixel exceeds `max(length, width) / 10`,
 hull outline below that, circle when heading is unknown.
 
@@ -850,6 +850,143 @@ ros2 launch marine_simulation sim_robot_launch.py \
 about 74 minutes. A vessel that enters on a high tide can strand minutes
 later on charted ground that was navigable when it arrived -- realistic
 behaviour at an unrealistic rate. Use `1` for sustained work.
+
+## `scripts/publish_history_tiles.py`
+
+Pre-renders days that have already been surveyed into their own static pyramid
+at `live/history/`, from the finished QPS exports, and publishes a small
+manifest beside them.
+
+It exists because the live coverage layer is a projection of what the boat's
+coverage source holds **right now**. Reset that source, or start a new day
+against a fresh store, and every earlier day leaves the map -- the same seabed,
+the same survey, gone from the display the operator uses to decide where to
+run next. `coverage_renderer` is deliberately memory-only (see [Memory-only, by
+design](#memory-only-by-design)) and should stay that way; a finished day is
+better carried by the thing that already has it, a finished grid.
+
+### It is a separate layer, not more coverage tiles
+
+Live coverage asserts something history does not: *the sonar is on this ground
+now*. The page spends real machinery on that claim -- a heartbeat manifest, a
+staleness fade, a footprint outline. A finished day supports none of it, and
+publishing it into `live/coverage/` would attach the live claim to ground the
+boat left days ago.
+
+That is not hypothetical. On 2026-08-27, with the coverage source reset for
+the day, `live/coverage/15/` still held 35 tiles from the 24th and the 26th --
+the un-publish bookkeeping is per-run and in memory, so tiles published by an
+earlier run are never cleaned up (see [Publishing and
+un-publishing](#publishing-and-un-publishing)). The page drew all of them in
+full live styling. Previous days were already on the map; what was missing was
+any way to tell them from today.
+
+So history gets its own prefix, its own manifest, and its own pane at
+`zIndex 340` -- below the coverage pane's 350, so today's line draws over the
+ground it re-runs, and outside the `.leaflet-coverage-pane` filter, so the live
+footprint outline stays the live footprint's.
+
+### Muting, and why the colours deliberately do not match
+
+The exports carry QPS's rainbow ramp, not the page's pinned 0-40 m blue-green
+one. They cannot be recoloured onto it: they are 8-bit RGBA with hillshade
+baked in -- 211,575 distinct colours over 1.46 M data pixels in the Day 2
+export -- so colour does not invert back to depth. A float depth grid would be
+a better input and could be coloured on the page's own ramp; that is a
+different pipeline, and this one is what the exports on hand support.
+
+Rather than ship a second saturated ramp beside the live one, the publisher
+desaturates toward a **warm** neutral and lightens (`--saturation`,
+`--lighten`; defaults 0.18 and 0.28, with the layer drawn at 0.80 opacity).
+The divergence then becomes the signal: old is warm and muted, live is cool
+and vivid, and the two read as different things before the operator reaches
+the outline or the readout. What survives the mute is relief and footprint,
+which is what a history layer is for. What is destroyed is any invitation to
+compare its colours against the live layer's as though they were one scale --
+which is also why the depth legend is not extended to cover it.
+
+The mute is **affine** in RGB, so it commutes with the averaging gdal2tiles
+does to build overview levels: muting the source once and tiling the result is
+the same as tiling and muting every tile. `test_history_tiles.py` pins that,
+because a non-affine mute (a gamma, an HSV round trip) would silently colour
+the overview levels differently from the native one -- the same ground
+changing colour as you zoom.
+
+### What it does
+
+1. Mutes each source into the workdir, row-blocked -- these exports are
+   ~8700 x 10200 and a whole-array float copy is over a gigabyte on a host
+   that is also running a survey. Alpha is copied through untouched: muting is
+   about colour, and touching alpha would move the footprint boundary.
+2. Warps them into one Web Mercator mosaic in **one** `gdal.Warp` call over
+   the whole list, oldest first. Not a VRT: a VRT stacks sources band by band
+   with no notion of alpha, so a later day's *transparent* pixels overwrite an
+   earlier day's data and punch the previous day full of holes. Warp reads the
+   source alpha as a validity mask, which is what "later sources win where
+   they overlap" has to mean.
+3. Cuts an **XYZ** pyramid with `gdal2tiles` (`--xyz` is load-bearing: the
+   default is TMS, whose Y axis runs the other way, and every tile would still
+   resolve and return 200 with the survey mirrored about the equator).
+   `--exclude` drops fully transparent tiles -- these exports are survey lines
+   inside a box that is ~1.5 % covered, so without it the run publishes
+   thousands of empty PNGs. Measured on the two Isles of Shoals days: 2,662
+   tiles down to 218, 17 MB down to 7 MB.
+4. Uploads, then writes `index.json` (the key list) and `meta.json` (the
+   page-facing manifest) **in that order, manifest last** -- the manifest must
+   not advertise a pyramid that is not fully uploaded, and the index must not
+   still describe the previous one once these tiles are live.
+5. Un-publishes: keys the previous run wrote that this one did not are
+   deleted. A static pyramid has no next pass to heal in, and the page paints
+   a miss transparent, so a stranded tile is served as current forever.
+
+### Parameters worth knowing
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--labels` | *(each file's basename)* | Comma-separated, matched to the sources **in order**. Deliberately **not** derived from mtime: an export written the morning after a survey dates the export, not the survey, and would publish a confidently wrong date |
+| `--dry-run` | off | Renders into `web/live/history/`, touching no AWS credential -- the same relative path the bucket serves, so the page previews identically |
+| `--profile` | `p11-renderer` | The boat-side credential, scoped to `s3:PutObject` on `live/*`. That scope is why this prefix lives under `live/` and not beside `tiles/` |
+| `--saturation` / `--lighten` | `0.18` / `0.28` | Re-tune the mute. Changing either re-renders the pyramid; the layer's *opacity* comes from the manifest instead, so that one is a page-side tweak |
+| `--min-zoom` / `--max-zoom` | `13` / *(derived)* | The max is computed from the mosaic resolution, rounded to the nearest level and capped at 18. A 1 m grid at 43 N is ~1.37 Web Mercator m/px, which lands on z17 |
+
+Sources are given **oldest first**. A run takes about 15 s for two days of
+Isles of Shoals coverage, and holds a per-user run lock for its duration --
+two concurrent runs would race the un-publish, with one deleting tiles the
+other had just published.
+
+```bash
+# Preview locally, no credentials touched.
+./scripts/publish_history_tiles.py --dry-run \
+    ~/'Shoals Day1_1m_CUBE_ITRF2020.tif' ~/Shoals2026_Day2_1m_CUBE_ITRF2020.tif
+
+# Publish.
+./scripts/publish_history_tiles.py --labels 2026-08-25,2026-08-26 \
+    ~/'Shoals Day1_1m_CUBE_ITRF2020.tif' ~/Shoals2026_Day2_1m_CUBE_ITRF2020.tif
+```
+
+### The page side
+
+`meta.json` carries `min_zoom`, `max_zoom`, `tiles`, `labels`, `bounds`,
+`opacity` and a stamp. The page builds the layer from it rather than
+hardcoding a zoom -- the same lesson `coverage_renderer`'s manifest exists for
+-- and validates it the same way, because it is remote JSON that configures
+`minZoom`/`minNativeZoom`: integer zooms in 0..22 through the shared
+`saneZoom`, plus an ordering check, since an inverted pair describes a pyramid
+that cannot exist and Leaflet does not reject it.
+
+`bounds` is `[[south, west], [north, east]]` -- Leaflet's order, the reverse of
+the GeoJSON `[lon, lat]` the state renderer publishes. Both orders are live on
+this page.
+
+The layer rebuilds only when the pyramid's **shape** changes (zooms, opacity,
+tile count, labels), not on every poll: a rebuild re-requests every visible
+tile, which is right when a new day lands and pure churn on the other 287
+polls of the day. The poll runs every 5 minutes and exists so a viewer who
+left the page open overnight picks up yesterday without a reload.
+
+No history published is the ordinary state on day one and reads as *none
+published*. A manifest that stops describing a pyramid takes the layer down
+with it, rather than leaving it claiming days the bucket may no longer serve.
 
 ## `scripts/refresh_chart_tiles.py`
 

--- a/marine_web_view/launch/web_view_launch.py
+++ b/marine_web_view/launch/web_view_launch.py
@@ -172,23 +172,31 @@ def generate_launch_description():
             'chart_datum_frame', default_value=[platform, '/chart_datum'],
             description='Vertical reference to colour depths against.'),
 
-        # Deliberately BELOW coverage_renderer's own default, which equals its
-        # render_interval. At equality a redraw issued the moment new tiles
-        # land is answered from the browser's cache -- the tile it holds is
-        # still inside its max-age -- and CloudFront can serve an already-stale
-        # copy on top of that. The page only redraws when the manifest's tile
-        # counter advances, so the stale frame is not corrected 20 s later; it
-        # waits for the NEXT advance, which on a slow survey line is minutes.
-        # Reported from the boat as coverage that updates only on a manual
-        # browser refresh. Strictly less than render_interval means every
-        # next-pass redraw is guaranteed to miss cache. Costs some extra tile
-        # GETs; the manifest's own max-age is min(5, this) and is unaffected.
+        # This value does NOT govern whether the browser refetches a redrawn
+        # tile. An earlier pass here set it below render_interval on the theory
+        # that a redraw would then land on an expired tile; measurement showed
+        # that could not work, because Leaflet's redraw() rebuilds tile elements
+        # with the SAME src and Chrome answers those from the document's
+        # in-memory resource cache without revalidating at all. Across seven
+        # redraws spanning 36 s against tiles carrying max-age=10, an existing
+        # tile was requested exactly ONCE. No max-age short of no-store changes
+        # that, and no-store would put every tile GET on the origin for every
+        # viewer.
+        #
+        # Browser refetch is handled instead by versioning the tile URL with the
+        # renderer's published-tile counter (see web/index.html buildCoverage).
+        # What cache_control still governs is CDN/origin revalidation of a tile
+        # object that was OVERWRITTEN in place at the same key -- so it bounds
+        # how long an edge may serve a superseded copy of an unchanged URL.
+        # There is no longer any constraint tying it to render_interval.
+        # The manifest's own max-age is min(5, this) and is unaffected.
         DeclareLaunchArgument(
             'cache_control', default_value='10',
-            description='max-age stamped on each coverage tile. Keep it '
-                        'STRICTLY below render_interval or the display can '
-                        'sit on a cached tile until the next counter '
-                        'advance.'),
+            description='max-age stamped on each coverage tile. Bounds how '
+                        'long a CDN edge may serve a superseded copy of an '
+                        'overwritten tile. It does NOT control browser '
+                        'refetch on redraw -- the versioned tile URL does '
+                        'that.'),
     ]
 
     renderers = [

--- a/marine_web_view/launch/web_view_launch.py
+++ b/marine_web_view/launch/web_view_launch.py
@@ -168,6 +168,24 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'chart_datum_frame', default_value=[platform, '/chart_datum'],
             description='Vertical reference to colour depths against.'),
+
+        # Deliberately BELOW coverage_renderer's own default, which equals its
+        # render_interval. At equality a redraw issued the moment new tiles
+        # land is answered from the browser's cache -- the tile it holds is
+        # still inside its max-age -- and CloudFront can serve an already-stale
+        # copy on top of that. The page only redraws when the manifest's tile
+        # counter advances, so the stale frame is not corrected 20 s later; it
+        # waits for the NEXT advance, which on a slow survey line is minutes.
+        # Reported from the boat as coverage that updates only on a manual
+        # browser refresh. Strictly less than render_interval means every
+        # next-pass redraw is guaranteed to miss cache. Costs some extra tile
+        # GETs; the manifest's own max-age is min(5, this) and is unaffected.
+        DeclareLaunchArgument(
+            'cache_control', default_value='10',
+            description='max-age stamped on each coverage tile. Keep it '
+                        'STRICTLY below render_interval or the display can '
+                        'sit on a cached tile until the next counter '
+                        'advance.'),
     ]
 
     renderers = [
@@ -182,6 +200,7 @@ def generate_launch_description():
             'coverage_namespace': LaunchConfiguration('coverage_namespace'),
             'map_frame': LaunchConfiguration('map_frame'),
             'chart_datum_frame': LaunchConfiguration('chart_datum_frame'),
+            'cache_control': LaunchConfiguration('cache_control'),
             'bucket': bucket,
             'profile': profile,
             'dry_run': dry_run,

--- a/marine_web_view/marine_web_view/coverage_renderer.py
+++ b/marine_web_view/marine_web_view/coverage_renderer.py
@@ -505,7 +505,31 @@ class CoverageRenderer(Node):
 
         namespace = str(self._param('coverage_namespace')).rstrip('/')
         latched = QoSProfile(depth=1)
-        latched.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
+        # ------------------------------------------------------------------
+        # FIELD WORKAROUND 2026-08-26 -- NOT the intended QoS. REVERT to
+        # TRANSIENT_LOCAL once the relay is fixed.
+        #
+        # The producer publishes this catalog transient_local
+        # (cube_bathymetry_node.cpp:515, "transient_local for late joiners"),
+        # and TRANSIENT_LOCAL is the correct request. But udp_bridge
+        # republishes it VOLATILE on the operator side, and a TRANSIENT_LOCAL
+        # subscriber cannot match a VOLATILE publisher -- so this node
+        # received no catalog at all, never reconciled, and could only paint
+        # the handful of tiles pushed to it on coverage_tiles. CAMP hides the
+        # same break because it warm-loads a disk cache; this renderer is
+        # memory-only, so a restart left the page nearly empty.
+        #
+        # VOLATILE matches the relay and gets the survey back on the page.
+        # What it costs is late-join: with no latched sample, this node sees
+        # nothing until the producer's next periodic publish. That is ~6 s
+        # during an active survey (measured 5 catalog messages in 30 s), so
+        # the cost is small WHILE THE PRODUCER IS RUNNING -- and unbounded if
+        # it is not, which is exactly the case transient_local exists for.
+        #
+        # The real fix is in the relay: preserve the producer's durability
+        # instead of downgrading it. Tracked for wrap-up.
+        # ------------------------------------------------------------------
+        latched.durability = QoSDurabilityPolicy.VOLATILE
         latched.reliability = QoSReliabilityPolicy.RELIABLE
         # Depth 10, matching the producer (cube_bathymetry_node.cpp:513) and
         # CAMP's consumer. A deeper queue on a BEST_EFFORT topic does not make

--- a/marine_web_view/marine_web_view/coverage_renderer.py
+++ b/marine_web_view/marine_web_view/coverage_renderer.py
@@ -526,8 +526,27 @@ class CoverageRenderer(Node):
         # the cost is small WHILE THE PRODUCER IS RUNNING -- and unbounded if
         # it is not, which is exactly the case transient_local exists for.
         #
-        # The real fix is in the relay: preserve the producer's durability
-        # instead of downgrading it. Tracked for wrap-up.
+        # CORRECTED at import review: the relay is NOT at fault and needs no
+        # change. udp_bridge already supports per-topic transient-local
+        # durability (its doc/qos_design.md, "Durability"), and deliberately
+        # does not auto-mirror source QoS -- that is a recorded decision with
+        # its own reasoning. The boat's bridge config simply never set
+        # `durability: transient_local` on coverage_catalog, so the topic took
+        # the documented VOLATILE default.
+        #
+        # REVERT THIS TO TRANSIENT_LOCAL once that config lands. The fix and
+        # the coupled revert here and in CAMP are tracked as
+        # rolker/unh_echoboats_project11#484. README.md's QoS table documents
+        # the intended TRANSIENT_LOCAL for this topic and is the shape to
+        # return to.
+        #
+        # Nothing will prompt the revert, which is why it is written here: a
+        # transient-local publisher still MATCHES a volatile subscriber, so
+        # once the config lands this node keeps working and keeps silently
+        # losing late-join. Note also that the relay is not always in the path
+        # -- the 2026-09-01 field log records coverage reaching the operator
+        # over a direct rmw_zenoh route -- and in that case this downgrade
+        # costs late-join for no reason at all.
         # ------------------------------------------------------------------
         latched.durability = QoSDurabilityPolicy.VOLATILE
         latched.reliability = QoSReliabilityPolicy.RELIABLE

--- a/marine_web_view/scripts/publish_history_tiles.py
+++ b/marine_web_view/scripts/publish_history_tiles.py
@@ -404,6 +404,13 @@ def mosaic_bounds(dataset):
     convert = osr.CoordinateTransformation(source, target)
     west, south = convert.TransformPoint(left, bottom)[:2]
     east, north = convert.TransformPoint(right, top)[:2]
+    # Released here, transform first. The CoordinateTransformation holds both
+    # SpatialReferences, and left to interpreter shutdown SWIG cannot find a
+    # destructor for them -- every run ended with two "detected a memory leak
+    # of type OSRSpatialReferenceShadow" lines on stderr. Harmless, and
+    # exactly the kind of harmless that trains an operator to ignore this
+    # script's output.
+    del convert, source, target
     return [[south, west], [north, east]]
 
 

--- a/marine_web_view/scripts/publish_history_tiles.py
+++ b/marine_web_view/scripts/publish_history_tiles.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Roland Arsenault
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Roland Arsenault nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Pre-render previously surveyed days into a static tile pyramid in S3.
+
+WHY: the live coverage layer shows what the boat's coverage source holds RIGHT
+NOW. Reset that source -- or start a new day against a fresh store -- and every
+earlier day leaves the map, even though it is the same seabed and the operator
+still needs to see which ground has already been run. The surveyed days do
+exist ashore, as QPS exports on disk. This turns them into their own static
+pyramid under the live layer, so history is carried by the thing that has it
+(a finished grid) rather than by asking a live renderer to hold a survey's
+worth of state it deliberately does not keep (see "Memory-only, by design" in
+the package README).
+
+WHY MUTED: the export carries QPS's own rainbow ramp with hillshade baked in,
+which is NOT the page's pinned 0-40 m blue-green scale -- the same depth is a
+different colour in each. That cannot be fixed by recolouring: 211,575 distinct
+colours over 1.46 M data pixels in the Day 2 export says shading is baked into
+the RGB, so the mapping from colour back to depth is not invertible. So the
+divergence is turned into the signal instead. History is desaturated toward a
+warm neutral and lightened; live coverage stays cool and vivid. The hue axis
+alone then says old-vs-new, before the operator reads the footprint outline or
+the readout. What survives the mute is relief and footprint -- which is what a
+history layer is actually for -- and what is deliberately destroyed is any
+invitation to compare its colours with the live layer's as if they were one
+scale.
+
+The mute is AFFINE in RGB (a luminance blend, a tint multiply, a lighten), so
+it commutes with the averaging gdal2tiles does to build overview levels. Muting
+the source once and tiling the result gives the same pixels as tiling first and
+muting every tile; test_history_tiles.py pins that.
+
+WHEN TO RE-RUN: whenever a new day's export lands. The run is idempotent --
+same sources in, same tiles out -- and it un-publishes: tiles the previous run
+left behind that this one does not produce are deleted, so a shrinking or
+re-cut mosaic does not strand PNGs the page will still fetch.
+
+DEPENDENCIES: stdlib, numpy, GDAL's Python bindings, and boto3. Nothing from
+marine_web_view -- like refresh_chart_tiles.py this is meant to run from a
+plain shell (or cron) with no ROS overlay sourced. GDAL and boto3 are imported
+lazily so the pure-computation entry points, and this package's tests, work
+without either.
+
+  Local preview -- writes into web/live/history/, so opening web/index.html
+  shows the layer exactly as the bucket will serve it:
+      ./publish_history_tiles.py --dry-run \
+          ~/'Shoals Day1_1m_CUBE_ITRF2020.tif' \
+                                           ~/Shoals2026_Day2_1m_CUBE_ITRF2020.tif
+
+  Publish, oldest source FIRST (later sources win where they overlap):
+      ./publish_history_tiles.py --labels 2026-08-25,2026-08-26 \
+          ~/'Shoals Day1_1m_CUBE_ITRF2020.tif' \
+          ~/Shoals2026_Day2_1m_CUBE_ITRF2020.tif
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+BUCKET = 'unh-ccom-p11-live'
+
+# Under live/, and that is not cosmetic: the p11-renderer credential the boat
+# publishes with is scoped to s3:PutObject on live/* only. A sibling top-level
+# prefix would need an IAM change and an admin profile -- which is exactly why
+# refresh_chart_tiles.py has to run under ccom-jhc to write tiles/.
+PREFIX = 'live/history/'
+META_KEY = PREFIX + 'meta.json'
+
+# The key index is a SEPARATE object from the manifest on purpose.
+# Un-publishing needs the full list of keys the last run wrote --
+# hundreds of strings -- and
+# meta.json is fetched by every viewer on a poll. Carrying the index in it
+# would put ~30 KB of bookkeeping on the page's budget to serve four numbers.
+INDEX_KEY = PREFIX + 'index.json'
+
+# A day that has been surveyed does not change. Cache the tiles hard; the
+# manifest is what a viewer re-reads to notice that a NEW day was added, so it
+# gets a short one of its own.
+TILE_EXTRA_ARGS = {'ContentType': 'image/png',
+                   'CacheControl': 'public,max-age=86400'}        # 1 day
+META_EXTRA_ARGS = {'ContentType': 'application/json',
+                   'CacheControl': 'public,max-age=300'}          # 5 minutes
+
+# ---------------------------------------------------------------------------
+# The mute. Defaults chosen against a composite of the real Day 2 export under
+# a mock live swath (the page's own ramp at its real 0.95 opacity) over Esri
+# imagery water, which is the only comparison that answers the question this
+# layer has to answer: does fresh coverage still read as fresh?
+#
+# `MUTE_OPACITY` is NOT baked into the tiles. It is reported in the manifest
+# and applied by the page as the layer's opacity, so the balance between
+# the two
+# layers can be re-tuned with a page edit instead of a re-render of the
+# pyramid.
+MUTE_SATURATION = 0.18      # 0 = greyscale, 1 = the export's own colours
+MUTE_LIGHTEN = 0.28         # blend toward white; "old" in the page's idiom
+MUTE_TINT = (1.00, 0.955, 0.86)   # warm, so the hue axis opposes the live ramp
+MUTE_OPACITY = 0.80
+
+# Rec. 601 luma, the same weights the page's own hillshade reasoning assumes.
+LUMA = (0.299, 0.587, 0.114)
+
+# Zoom bounds. The floor is not a detail: the page's map has minZoom 8, and a
+# tile layer whose minNativeZoom sits above the current map zoom is laid out by
+# Leaflet in tiles OF THAT NATIVE ZOOM -- 4^n of them (web/index.html documents
+# the browser freeze this causes). The page hides the layer below its own
+# min_zoom, and rendering down to 13 keeps that hide-point close enough to the
+# map's floor that the layer is not simply absent for anyone zoomed out.
+ZOOM_FLOOR = 13
+# The ceiling bounds cost, not quality: each extra level is 4x the tiles for
+# ground that a 1 m grid cannot resolve further anyway.
+ZOOM_CEILING = 18
+
+# Web Mercator, the numbers gdal2tiles works in.
+MERCATOR_CIRCUMFERENCE = 40075016.6855785
+TILE_SIZE = 256
+
+# Bound the fan-out the same way refresh_chart_tiles.py does, and for the same
+# reason: this is our own bucket, but an unbounded pool against a slow endpoint
+# is just a queue that fails all at once.
+DEFAULT_CONCURRENCY = 10
+UPLOAD_DEADLINE_SECONDS = 1800
+
+# A held lock older than this is a wedged run, not a slow one: a full pyramid
+# over a few km2 is minutes.
+LOCK_STALE_SECONDS = 3600
+
+
+# ---------------------------------------------------------------------------
+# Pure computation. No GDAL, no boto3, no filesystem -- this is the part the
+# tests can exercise directly.
+# ---------------------------------------------------------------------------
+
+def mute_rgb(rgb, saturation=MUTE_SATURATION, lighten=MUTE_LIGHTEN,
+             tint=MUTE_TINT):
+    """Desaturate, tint and lighten an RGB array of floats in 0..255.
+
+    Affine in `rgb` -- deliberately. gdal2tiles builds every overview level by
+    averaging the level below it, and an affine function commutes with an
+    average, so muting the source and tiling it produces the same pyramid as
+    tiling the source and muting each tile. That equivalence is what lets this
+    run once over the source instead of over every tile at every level.
+
+    Nothing is clipped here. The caller writes into a uint8 band and clips
+    there; clipping twice would be the same operation and it is easier to
+    reason about the arithmetic when it stays linear all the way through.
+    """
+    weights = np.array(LUMA, dtype=np.float32)
+    luma = np.tensordot(rgb, weights, axes=([-1], [0]))[..., None]
+    out = luma + (rgb - luma) * float(saturation)
+    out = out * np.array(tint, dtype=np.float32)
+    return out * (1.0 - float(lighten)) + 255.0 * float(lighten)
+
+
+def zoom_range(resolution, floor=ZOOM_FLOOR, ceiling=ZOOM_CEILING):
+    """Return (min_zoom, max_zoom) for a mosaic at `resolution` m/px.
+
+    `resolution` is in Web Mercator metres, which are the source's ground
+    metres divided by cos(latitude) -- at 43 N a 1 m grid is about 1.37 m/px
+    here. Rounding to the NEAREST level rather than up is the point: rounding
+    up buys a level of empty magnification and 4x the tiles.
+    """
+    if not resolution > 0:
+        raise ValueError('resolution must be positive, got {!r}'.format(
+            resolution))
+    native = np.log2(MERCATOR_CIRCUMFERENCE / (TILE_SIZE * resolution))
+    top = int(min(ceiling, max(floor, round(native))))
+    return floor, top
+
+
+def plan_removals(previous_keys, current_keys):
+    """Return the keys a previous run published that this one did not.
+
+    A tile PNG stands in the bucket until something overwrites or deletes it,
+    and the page paints a miss transparent -- so ground that has dropped out of
+    the mosaic (a source withdrawn, a re-cut that no longer reaches a tile)
+    keeps being served from the old render with nothing to reveal that it is
+    stale. The live coverage renderer un-publishes for exactly this reason;
+    this is the same discipline, done across runs because a static pyramid has
+    no next pass to heal in.
+
+    Sorted so a run's deletions are reproducible and reviewable.
+    """
+    return sorted(set(previous_keys) - set(current_keys))
+
+
+def build_manifest(min_zoom, max_zoom, tile_count, sources, bounds, stamp):
+    """Assemble the page-facing manifest.
+
+    Small by construction -- every viewer polls it. The key index that
+    un-publishing needs lives in its own object (see INDEX_KEY).
+
+    `bounds` is [[south, west], [north, east]] in degrees: Leaflet's own
+    LatLngBounds order, so the page can hand it straight to fitBounds without
+    a coordinate swap. That is the reverse of GeoJSON's [lon, lat], and the
+    two orders being reversed from each other is a standing trap in this page
+    (state_renderer's output is GeoJSON and IS [lon, lat]).
+    """
+    return {
+        'min_zoom': int(min_zoom),
+        'max_zoom': int(max_zoom),
+        'tiles': int(tile_count),
+        'sources': list(sources),
+        'labels': [source['label'] for source in sources],
+        'bounds': bounds,
+        'opacity': MUTE_OPACITY,
+        'mute': {'saturation': MUTE_SATURATION, 'lighten': MUTE_LIGHTEN,
+                 'tint': list(MUTE_TINT)},
+        'prefix': PREFIX.rstrip('/'),
+        'stamp': float(stamp),
+        'generated': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(stamp)),
+    }
+
+
+def resolve_labels(paths, labels):
+    """Pair each source path with the label it will be published under.
+
+    Labels are NOT derived from the file's mtime, and that is a correctness
+    decision rather than laziness: an export written the morning after a survey
+    carries the wrong date, so mtime would silently publish "2026-08-26" over
+    ground that was run on the 25th. Absent an explicit --labels, the basename
+    is used -- which is merely unhelpful, where an invented date is wrong.
+    """
+    if not labels:
+        return [os.path.splitext(os.path.basename(p))[0] for p in paths]
+    if len(labels) != len(paths):
+        raise ValueError(
+            '--labels has {} entries for {} sources; they are matched in '
+            'order, so give one per source or none at all'.format(
+                len(labels), len(paths)))
+    return list(labels)
+
+
+# ---------------------------------------------------------------------------
+# Raster. GDAL is imported inside these, not at module scope, so the pure half
+# above stays importable (and testable) on a host without the bindings.
+# ---------------------------------------------------------------------------
+
+def _gdal():
+    """Return the GDAL module with exceptions on.
+
+    UseExceptions() is not optional: without it GDAL reports failure by
+    returning None and setting a global error string, so a warp that produced
+    nothing carries on to gdal2tiles as an empty mosaic and publishes a
+    pyramid of transparent tiles over the ground it was meant to show.
+    """
+    from osgeo import gdal
+    gdal.UseExceptions()
+    return gdal
+
+
+def open_source(path):
+    """Open an RGBA export and refuse anything this script cannot honour.
+
+    Checked here rather than left to fail downstream, because each of these
+    fails QUIETLY further along:
+
+    - no alpha band: the mosaic has no notion of "not surveyed", so the
+      export's own background floods every tile it touches and the history
+      layer becomes an opaque rectangle over the chart.
+    - not 8-bit: mute_rgb's arithmetic is in 0..255 and the tint/lighten
+      constants are meaningless against a float depth band. A float export is
+      a BETTER input than this one -- it could be coloured on the page's own
+      ramp -- but it is a different pipeline, not this one with a wider dtype.
+    - no projection: gdal.Warp would have nothing to warp from and lands the
+      mosaic at the origin, which puts a survey off West Africa.
+    """
+    gdal = _gdal()
+    dataset = gdal.Open(path)
+    if dataset.RasterCount != 4:
+        raise ValueError(
+            '{}: expected an RGBA export, got {} band(s). A single-band depth '
+            'grid needs the page ramp, not this script.'.format(
+                path, dataset.RasterCount))
+    types = {gdal.GetDataTypeName(dataset.GetRasterBand(i).DataType)
+             for i in range(1, 5)}
+    if types != {'Byte'}:
+        raise ValueError('{}: expected 8-bit bands, got {}'.format(
+            path, ', '.join(sorted(types))))
+    interp = gdal.GetColorInterpretationName(
+        dataset.GetRasterBand(4).GetColorInterpretation())
+    if interp != 'Alpha':
+        raise ValueError(
+            '{}: band 4 is {}, not Alpha -- without a validity mask the '
+            'export would be mosaicked as an opaque rectangle'.format(
+                path, interp))
+    if not dataset.GetProjection():
+        raise ValueError('{}: no projection; refusing to guess one'.format(
+            path))
+    return dataset
+
+
+def mute_source(path, destination, saturation=MUTE_SATURATION,
+                lighten=MUTE_LIGHTEN, tint=MUTE_TINT, block_rows=512):
+    """Write a muted copy of `path` to `destination`, georeferencing intact.
+
+    Row-blocked because these exports are ~8700 x 10200: read whole, the
+    float32 working copy alone is over a gigabyte, on a host that is also
+    running a survey. Alpha is copied through untouched -- muting is about
+    colour, and touching alpha would move the footprint boundary, which is the
+    one thing in this layer that must stay exactly where the sonar put it.
+    """
+    gdal = _gdal()
+    source = open_source(path)
+    width, height = source.RasterXSize, source.RasterYSize
+    driver = gdal.GetDriverByName('GTiff')
+    out = driver.Create(destination, width, height, 4, gdal.GDT_Byte,
+                        options=['COMPRESS=LZW', 'TILED=YES', 'BIGTIFF=YES'])
+    out.SetGeoTransform(source.GetGeoTransform())
+    out.SetProjection(source.GetProjection())
+    out.GetRasterBand(4).SetColorInterpretation(gdal.GCI_AlphaBand)
+    for top in range(0, height, block_rows):
+        rows = min(block_rows, height - top)
+        rgb = np.dstack([source.GetRasterBand(i).ReadAsArray(0, top, width,
+                                                             rows)
+                         for i in (1, 2, 3)]).astype(np.float32)
+        muted = np.clip(mute_rgb(rgb, saturation, lighten, tint), 0, 255)
+        for index in (1, 2, 3):
+            out.GetRasterBand(index).WriteArray(
+                muted[..., index - 1].astype(np.uint8), 0, top)
+        out.GetRasterBand(4).WriteArray(
+            source.GetRasterBand(4).ReadAsArray(0, top, width, rows), 0, top)
+    out.FlushCache()
+    return destination
+
+
+def mosaic_to_mercator(paths, destination):
+    """Warp `paths` into one Web Mercator RGBA mosaic, later sources on top.
+
+    One gdal.Warp call over the whole list rather than a VRT: a VRT stacks its
+    sources band by band with no notion of alpha, so a later source's
+    TRANSPARENT pixels overwrite an earlier source's data and punch the
+    previous day's coverage full of holes wherever the current day's export
+    merely extends past it. Warp reads the source alpha as a validity mask, so
+    each source paints only where it actually has ground -- which is what
+    "later sources win where they overlap" has to mean.
+
+    Bilinear, not cubic: cubic rings at the hard alpha edge these exports have,
+    and a bright halo tracing every survey line is exactly the kind of artifact
+    that gets read as data.
+    """
+    gdal = _gdal()
+    warped = gdal.Warp(destination, list(paths), dstSRS='EPSG:3857',
+                       srcAlpha=True, dstAlpha=True, resampleAlg='bilinear',
+                       multithread=True,
+                       creationOptions=['COMPRESS=LZW', 'TILED=YES',
+                                        'BIGTIFF=YES'])
+    warped.FlushCache()
+    return warped
+
+
+def mosaic_bounds(dataset):
+    """Return [[south, west], [north, east]] in degrees for a 3857 dataset."""
+    from osgeo import osr
+    transform = dataset.GetGeoTransform()
+    left, top = transform[0], transform[3]
+    right = left + transform[1] * dataset.RasterXSize
+    bottom = top + transform[5] * dataset.RasterYSize
+    source = osr.SpatialReference(wkt=dataset.GetProjection())
+    target = osr.SpatialReference()
+    target.ImportFromEPSG(4326)
+    # Without this, GDAL 3 honours the authority's own axis order and hands
+    # back (lat, lon) for EPSG:4326 -- silently transposed, and a survey off
+    # the coast of Somalia.
+    target.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    convert = osr.CoordinateTransformation(source, target)
+    west, south = convert.TransformPoint(left, bottom)[:2]
+    east, north = convert.TransformPoint(right, top)[:2]
+    return [[south, west], [north, east]]
+
+
+def render_pyramid(source, outdir, min_zoom, max_zoom, processes=1):
+    """Cut `source` into an XYZ pyramid under `outdir`.
+
+    --xyz is load-bearing. gdal2tiles defaults to TMS, whose Y axis runs the
+    other way, and the page's tile URL is the plain Leaflet {z}/{x}/{y}. Get
+    this wrong and every tile resolves, every request returns 200, and the
+    survey appears mirrored about the equator -- no error anywhere.
+    """
+    from osgeo_utils import gdal2tiles
+    argv = ['gdal2tiles.py', '--profile=mercator', '--xyz',
+            '--zoom={}-{}'.format(min_zoom, max_zoom),
+            '--resampling=average', '--webviewer=none', '--no-kml',
+            # Without --exclude, gdal2tiles writes the mosaic's whole bounding
+            # RECTANGLE, empty tiles included. These exports are survey lines
+            # inside an 8 x 10 km box that is ~1.5 % covered, so that is
+            # thousands of fully transparent PNGs -- PUT, stored, served, and
+            # re-fetched by every viewer to paint nothing. The page already
+            # treats a missing tile as "not surveyed" (errorTileUrl), which is
+            # the same picture for free.
+            '--exclude',
+            '--processes={}'.format(processes), '-q', source, outdir]
+    status = gdal2tiles.main(argv)
+    if status:
+        raise RuntimeError('gdal2tiles exited {}'.format(status))
+    return outdir
+
+
+def walk_tiles(outdir):
+    """Return the pyramid's PNGs as (local path, key-relative path) pairs.
+
+    PNGs only: gdal2tiles also drops tilemapresource.xml and, depending on
+    version and options, a viewer HTML beside them. Uploading those would put
+    a second, unversioned description of the pyramid in the bucket next to the
+    manifest that is meant to be the only one.
+    """
+    found = []
+    for root, _, names in os.walk(outdir):
+        for name in sorted(names):
+            if not name.endswith('.png'):
+                continue
+            path = os.path.join(root, name)
+            found.append((path, os.path.relpath(path, outdir)))
+    return sorted(found, key=lambda pair: pair[1])
+
+
+# ---------------------------------------------------------------------------
+# Run lock. Same shape, and the same reasoning, as refresh_chart_tiles.py's.
+# ---------------------------------------------------------------------------
+
+def _lock_opener(path, flags):
+    """Open the lock file without following a symlink, mode 0600."""
+    # The caller's 'w' carries O_TRUNC, and truncating the lock file before
+    # knowing whether the flock succeeded destroys the holder record the
+    # failure path reads. Same reasoning as refresh_chart_tiles.py.
+    del flags
+    return os.open(path, os.O_CREAT | os.O_WRONLY | os.O_NOFOLLOW, 0o600)
+
+
+def lock_dir():
+    """Return a per-user directory to keep the run lock in.
+
+    NOT the workdir: that defaults under /tmp, a world-writable tree this
+    script does not own, where a squatted lock file would stop every future
+    run. $XDG_RUNTIME_DIR when there is one, ~/.cache otherwise (which is
+    where a cron run with no session lands).
+    """
+    base = os.environ.get('XDG_RUNTIME_DIR')
+    path = (os.path.join(base, 'p11-tiles') if base
+            else os.path.join(os.path.expanduser('~'), '.cache', 'p11-tiles'))
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    info = os.lstat(path)
+    if info.st_uid != os.geteuid():
+        raise RuntimeError('{} is owned by uid {}, not by this user'.format(
+            path, info.st_uid))
+    if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise RuntimeError(
+            '{} is group- or world-writable ({:o}); refusing to keep a run '
+            'lock there'.format(path, stat.S_IMODE(info.st_mode)))
+    return path
+
+
+def acquire_run_lock(name='history'):
+    """Take the exclusive run lock, or raise RuntimeError saying who holds it.
+
+    Two runs would interleave writes into the same prefix and, worse, race the
+    un-publish: run A's removal plan is computed against an index run B is in
+    the middle of replacing, so A deletes tiles B has just published and the
+    page serves holes over surveyed ground until someone notices.
+
+    The handle must stay referenced for the life of the run -- closing it
+    releases the lock. flock is released by the kernel on exit, so a killed
+    run strands nothing.
+    """
+    path = os.path.join(lock_dir(), '{}.lock'.format(name))
+    handle = open(path, 'w', opener=_lock_opener)
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        try:
+            with open(path) as held:
+                pid, started = held.read().split()[:2]
+            age = max(0.0, time.time() - int(started))
+        except (OSError, ValueError, IndexError):
+            pid, age = None, None
+        detail = '' if pid is None else ' by pid {} ({:.0f} s ago)'.format(
+            pid, age)
+        wedged = (age is not None and age > LOCK_STALE_SECONDS)
+        raise RuntimeError('{} is held{}{}'.format(
+            path, detail,
+            ' -- older than {} s, so that run is wedged, not slow'.format(
+                LOCK_STALE_SECONDS) if wedged else ''))
+    handle.truncate(0)
+    handle.write('{} {}\n'.format(os.getpid(), int(time.time())))
+    handle.flush()
+    return handle
+
+
+# ---------------------------------------------------------------------------
+# S3. boto3 is imported lazily for the same reason GDAL is.
+# ---------------------------------------------------------------------------
+
+def s3_client(profile):
+    """Build an S3 client for `profile`, or the default chain if it is empty.
+
+    An empty profile means "use boto3's own credential chain" -- how an
+    instance role is picked up with no key on disk -- and is passed as no
+    profile at all rather than as an empty string, matching how
+    coverage_renderer treats the same parameter.
+    """
+    import boto3
+    from botocore.config import Config
+    session = (boto3.Session(profile_name=profile) if profile
+               else boto3.Session())
+    return session.client('s3', config=Config(
+        connect_timeout=10, read_timeout=60,
+        retries={'max_attempts': 3, 'mode': 'standard'}))
+
+
+def load_index(client):
+    """Return the keys the previous run published, or [] if there is none.
+
+    A read that FAILS is not the same as an absent index, and the difference
+    is destructive: treating an unreadable index as empty makes this run's
+    removal plan empty too, which is the safe direction (nothing is deleted)
+    -- so it is deliberately not raised. What must never happen is the
+    reverse, deleting on no evidence, and that cannot arise from this shape.
+    """
+    try:
+        body = client.get_object(Bucket=BUCKET, Key=INDEX_KEY)
+        keys = json.loads(body['Body'].read())
+    except Exception:
+        return []
+    return [k for k in keys if isinstance(k, str)] if isinstance(keys, list) \
+        else []
+
+
+def upload_tiles(client, tiles, concurrency, deadline_seconds,
+                 log=print):
+    """PUT every tile, bounded by `concurrency` and an aggregate deadline.
+
+    The deadline is checked before a job STARTS rather than enforced per
+    request: a run that overruns leaves the manifest unwritten and the tiles
+    it did upload standing, which is recoverable by re-running. A run that
+    hangs forever holds the lock and stops every future one, which is not.
+    """
+    import concurrent.futures
+    started = time.monotonic()
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(concurrency) as pool:
+        futures = {}
+        for path, relative in tiles:
+            if time.monotonic() - started > deadline_seconds:
+                raise RuntimeError(
+                    'upload deadline ({} s) reached after {}/{} tiles; the '
+                    'manifest was NOT written, so the page still describes '
+                    'the previous pyramid. Re-run to finish.'.format(
+                        deadline_seconds, done, len(tiles)))
+            key = PREFIX + relative.replace(os.sep, '/')
+            futures[pool.submit(client.upload_file, path, BUCKET, key,
+                                ExtraArgs=TILE_EXTRA_ARGS)] = key
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+            done += 1
+            if done % 100 == 0:
+                log('  uploaded {}/{}'.format(done, len(tiles)))
+    return [PREFIX + rel.replace(os.sep, '/') for _, rel in tiles]
+
+
+def delete_keys(client, keys, log=print):
+    """Delete `keys` in batches of 1000, the DeleteObjects ceiling."""
+    for start in range(0, len(keys), 1000):
+        batch = keys[start:start + 1000]
+        client.delete_objects(
+            Bucket=BUCKET,
+            Delete={'Objects': [{'Key': k} for k in batch], 'Quiet': True})
+        log('  un-published {} tile(s)'.format(len(batch)))
+
+
+# ---------------------------------------------------------------------------
+# Local output, for --dry-run.
+# ---------------------------------------------------------------------------
+
+def default_local_dir():
+    """Return web/live/history/ inside this package.
+
+    The same relative path the bucket serves, so the page's relative URLs
+    resolve identically against a local copy and against CloudFront -- the
+    convention the renderers' own dry_run modes already follow.
+    """
+    package = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(package, 'web', 'live', 'history')
+
+
+def replace_local_dir(path):
+    """Empty `path` for a fresh local render, refusing anything unexpected.
+
+    An earlier preview has to go -- left in place, tiles from a previous
+    source list survive underneath the new ones and the preview shows a
+    mosaic the bucket would never serve. But this is an rm -rf against a path
+    that came off the command line, so it runs ONLY over a directory that
+    looks like a previous run of this script: empty, or holding nothing but
+    the pyramid and its two JSON objects. Anything else and the operator is
+    told to clear it themselves rather than having it done for them.
+    """
+    if not os.path.exists(path):
+        return
+    allowed = {'meta.json', 'index.json'}
+    for name in os.listdir(path):
+        if name in allowed or (name.isdigit() and os.path.isdir(
+                os.path.join(path, name))):
+            continue
+        raise RuntimeError(
+            '{} holds {!r}, which this script did not write. Refusing to '
+            'delete it -- clear the directory yourself, or point --local-dir '
+            'somewhere else.'.format(path, name))
+    shutil.rmtree(path)
+
+
+def write_local(outdir, local_dir, manifest, keys, log=print):
+    """Move a rendered pyramid and its JSON into `local_dir`."""
+    replace_local_dir(local_dir)
+    os.makedirs(os.path.dirname(local_dir), exist_ok=True)
+    shutil.move(outdir, local_dir)
+    for name, payload in (('meta.json', manifest), ('index.json', keys)):
+        with open(os.path.join(local_dir, name), 'w') as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+    log('wrote {} tile(s) to {}'.format(len(keys), local_dir))
+
+
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None):
+    """Parse the command line."""
+    parser = argparse.ArgumentParser(
+        description=__doc__.strip().splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('sources', nargs='+', metavar='GEOTIFF',
+                        help='RGBA exports, OLDEST FIRST -- later sources win '
+                             'where footprints overlap')
+    parser.add_argument('--labels', default='',
+                        help='comma-separated label per source, in the same '
+                             'order (e.g. survey dates). Defaults to each '
+                             "file's basename; deliberately NOT its mtime, "
+                             'which dates the export rather than the survey')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='render locally and touch no AWS credentials')
+    parser.add_argument('--local-dir', default=None,
+                        help='where --dry-run writes (default: the package '
+                             'web/live/history, where the page will find '
+                             'it)')
+    parser.add_argument('--profile', default='p11-renderer',
+                        help='AWS profile. The default is the boat-side '
+                             'credential, which can write live/* and nothing '
+                             'else -- which is why this prefix lives there. '
+                             'Empty means the default credential chain')
+    parser.add_argument('--saturation', type=float, default=MUTE_SATURATION)
+    parser.add_argument('--lighten', type=float, default=MUTE_LIGHTEN)
+    parser.add_argument('--min-zoom', type=int, default=ZOOM_FLOOR)
+    parser.add_argument('--max-zoom', type=int, default=None,
+                        help='default: derived from the mosaic resolution, '
+                             'capped at {}'.format(ZOOM_CEILING))
+    parser.add_argument('--concurrency', type=int,
+                        default=DEFAULT_CONCURRENCY)
+    parser.add_argument('--processes', type=int,
+                        default=max(1, (os.cpu_count() or 2) // 2),
+                        help='gdal2tiles worker processes')
+    parser.add_argument('--workdir', default=None,
+                        help='scratch for the muted sources and the mosaic '
+                             '(default: a temporary directory, removed on the '
+                             'way out)')
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """Render the history pyramid and publish it."""
+    args = parse_args(argv)
+    labels = [part for part in args.labels.split(',') if part]
+    try:
+        labels = resolve_labels(args.sources, labels)
+    except ValueError as exc:
+        print('error: {}'.format(exc), file=sys.stderr)
+        return 2
+    for path in args.sources:
+        if not os.path.isfile(path):
+            print('error: no such file: {}'.format(path), file=sys.stderr)
+            return 2
+
+    # Taken before any work: the point is to keep two runs from interleaving,
+    # and the expensive half is the render, not the upload.
+    try:
+        lock = acquire_run_lock()
+    except RuntimeError as exc:
+        print('error: {}'.format(exc), file=sys.stderr)
+        return 1
+
+    workdir = args.workdir or tempfile.mkdtemp(prefix='p11-history-')
+    os.makedirs(workdir, exist_ok=True)
+    temporary = args.workdir is None
+    try:
+        muted = []
+        for index, path in enumerate(args.sources):
+            print('muting {} ({})'.format(os.path.basename(path),
+                                          labels[index]))
+            muted.append(mute_source(
+                path, os.path.join(workdir, 'muted_{:02d}.tif'.format(index)),
+                saturation=args.saturation, lighten=args.lighten))
+
+        print('mosaicking {} source(s) to Web Mercator'.format(len(muted)))
+        mosaic_path = os.path.join(workdir, 'mosaic.tif')
+        mosaic = mosaic_to_mercator(muted, mosaic_path)
+        resolution = abs(mosaic.GetGeoTransform()[1])
+        bounds = mosaic_bounds(mosaic)
+        derived_min, derived_max = zoom_range(resolution)
+        min_zoom = args.min_zoom
+        max_zoom = args.max_zoom if args.max_zoom is not None else derived_max
+        if min_zoom > max_zoom:
+            print('error: --min-zoom {} is above --max-zoom {}'.format(
+                min_zoom, max_zoom), file=sys.stderr)
+            return 2
+        del derived_min
+        print('  {:.2f} m/px -> zoom {}-{}'.format(resolution, min_zoom,
+                                                   max_zoom))
+
+        outdir = os.path.join(workdir, 'tiles')
+        render_pyramid(mosaic_path, outdir, min_zoom, max_zoom,
+                       processes=args.processes)
+        tiles = walk_tiles(outdir)
+        if not tiles:
+            print('error: the render produced no tiles -- every source may be '
+                  'fully transparent, or outside the mosaic', file=sys.stderr)
+            return 1
+        print('rendered {} tile(s)'.format(len(tiles)))
+
+        sources = [{'file': os.path.basename(p), 'label': labels[i]}
+                   for i, p in enumerate(args.sources)]
+        manifest = build_manifest(min_zoom, max_zoom, len(tiles), sources,
+                                  bounds, time.time())
+
+        if args.dry_run:
+            keys = [PREFIX + rel.replace(os.sep, '/') for _, rel in tiles]
+            write_local(outdir, args.local_dir or default_local_dir(),
+                        manifest, keys)
+            return 0
+
+        client = s3_client(args.profile)
+        previous = load_index(client)
+        keys = upload_tiles(client, tiles, args.concurrency,
+                            UPLOAD_DEADLINE_SECONDS)
+
+        # Index BEFORE manifest, manifest LAST. The manifest is what the page
+        # reads, so it must not advertise a pyramid that is not fully
+        # uploaded; the index is what the NEXT run's un-publish is computed
+        # against, so it must not still describe the previous pyramid once
+        # these tiles are live.
+        client.put_object(Bucket=BUCKET, Key=INDEX_KEY,
+                          Body=json.dumps(sorted(keys)).encode(),
+                          ContentType='application/json',
+                          CacheControl='no-cache')
+        stale = plan_removals(previous, keys)
+        if stale:
+            delete_keys(client, stale)
+        client.put_object(Bucket=BUCKET, Key=META_KEY,
+                          Body=json.dumps(manifest, indent=2,
+                                          sort_keys=True).encode(),
+                          **META_EXTRA_ARGS)
+        print('published {} tile(s) to s3://{}/{} ({} un-published)'.format(
+            len(keys), BUCKET, PREFIX, len(stale)))
+        return 0
+    finally:
+        lock.close()
+        if temporary:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/marine_web_view/scripts/publish_history_tiles.py
+++ b/marine_web_view/scripts/publish_history_tiles.py
@@ -484,7 +484,14 @@ def lock_dir():
     path = (os.path.join(base, 'p11-tiles') if base
             else os.path.join(os.path.expanduser('~'), '.cache', 'p11-tiles'))
     os.makedirs(path, mode=0o700, exist_ok=True)
+    # lstat, not stat: a symlink here is exactly the substitution being guarded
+    # against, and stat() would follow it and report the target. A symlink is in
+    # practice already rejected by the mode check below (a link's own mode is
+    # 0o777), but only incidentally and with a misleading reason -- say what is
+    # actually wrong. refresh_chart_tiles.py carries the same guard.
     info = os.lstat(path)
+    if not stat.S_ISDIR(info.st_mode):
+        raise RuntimeError('{} is not a directory'.format(path))
     if info.st_uid != os.geteuid():
         raise RuntimeError('{} is owned by uid {}, not by this user'.format(
             path, info.st_uid))
@@ -583,7 +590,10 @@ def upload_tiles(client, tiles, concurrency, deadline_seconds,
     import concurrent.futures
     started = time.monotonic()
     done = 0
-    with concurrent.futures.ThreadPoolExecutor(concurrency) as pool:
+    # Clamp: ThreadPoolExecutor(0) raises ValueError, so an operator typo
+    # (--concurrency 0) would abort the run with a stack trace rather than a
+    # controlled error. refresh_chart_tiles.py clamps the same way.
+    with concurrent.futures.ThreadPoolExecutor(max(1, int(concurrency))) as pool:
         futures = {}
         for path, relative in tiles:
             if time.monotonic() - started > deadline_seconds:

--- a/marine_web_view/test/test_history_tiles.py
+++ b/marine_web_view/test/test_history_tiles.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Roland Arsenault
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the Roland Arsenault nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Guard the history publisher's pure half.
+
+The raster stages need GDAL and a survey-sized export, so they are exercised
+by running the script; what is pinned here is the arithmetic and the
+bookkeeping that decide what the page is served and what gets deleted from the
+bucket -- the two places where being quietly wrong is expensive.
+"""
+
+import importlib.util
+import json
+import os
+
+import numpy as np
+
+import pytest
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'scripts', 'publish_history_tiles.py')
+
+
+def _load_script():
+    """Import publish_history_tiles.py by path.
+
+    Safe to import: GDAL and boto3 are both reached for inside functions, so
+    module import needs nothing but numpy -- which is what lets this file run
+    in CI on a host with neither.
+    """
+    spec = importlib.util.spec_from_file_location('publish_history_tiles',
+                                                  _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPT = _load_script()
+
+
+def test_the_mute_commutes_with_averaging():
+    """The whole pipeline shape depends on this.
+
+    gdal2tiles builds every overview level by averaging the level below it.
+    Muting the source once and tiling the result is only equivalent to muting
+    every tile at every level if the mute is affine -- which is why it is a
+    luminance blend and a scale, and not a gamma, a clamp, or an HSV round
+    trip. Break that and the overview levels are muted differently from the
+    native one: the same ground changes colour as you zoom.
+    """
+    rng = np.random.default_rng(20260827)
+    block = rng.integers(0, 256, size=(4, 4, 3)).astype(np.float32)
+
+    muted_then_averaged = SCRIPT.mute_rgb(block).reshape(-1, 3).mean(axis=0)
+    averaged_then_muted = SCRIPT.mute_rgb(block.reshape(-1, 3).mean(axis=0))
+
+    assert np.allclose(muted_then_averaged, averaged_then_muted, atol=1e-3)
+
+
+def test_a_zero_saturation_mute_is_greyscale_before_the_tint():
+    """Saturation 0 must leave no hue difference for the tint to act on.
+
+    This is the knob an operator reaches for when the history layer is still
+    competing with live coverage, so it has to actually reach neutral rather
+    than merely desaturate a long way.
+    """
+    colours = np.array([[255., 0., 0.], [0., 255., 0.], [0., 0., 255.]])
+    muted = SCRIPT.mute_rgb(colours, saturation=0.0, lighten=0.0,
+                            tint=(1.0, 1.0, 1.0))
+    for row in muted:
+        assert np.allclose(row, row[0]), (
+            'saturation 0 left {} with a hue'.format(row))
+
+
+def test_the_mute_warms_rather_than_cools():
+    """The layer's whole job is to oppose the live ramp on the hue axis.
+
+    Live coverage is drawn from a blue-green ramp. If the mute ever drifts
+    cool, the two layers stop being distinguishable by colour and the operator
+    is back to reading the footprint outline to tell today from last Tuesday.
+    """
+    grey = np.array([[128., 128., 128.]])
+    muted = SCRIPT.mute_rgb(grey)[0]
+    assert muted[0] > muted[2], (
+        'a neutral input came out cool ({}): the tint no longer opposes the '
+        'live ramp'.format(muted))
+
+
+def test_the_zoom_range_rounds_to_the_nearest_level():
+    """Rounding up buys a level of empty magnification and 4x the tiles."""
+    # A 1 m grid at 43 N is ~1.37 Web Mercator m/px, which is z17's 1.19 and
+    # z16's 2.39 -- nearest is 17.
+    assert SCRIPT.zoom_range(1.37) == (13, 17)
+    # Just below z16's own resolution: still 16, not 17.
+    assert SCRIPT.zoom_range(2.30)[1] == 16
+
+
+def test_the_zoom_range_is_clamped_at_both_ends():
+    """A very fine or very coarse mosaic must not drive the tile count.
+
+    The ceiling is the one that costs money -- each level is 4x the tiles --
+    and the floor is what keeps the layer from being hidden at every zoom an
+    operator actually uses.
+    """
+    assert SCRIPT.zoom_range(0.001)[1] == SCRIPT.ZOOM_CEILING
+    assert SCRIPT.zoom_range(100000.0)[1] == SCRIPT.ZOOM_FLOOR
+    with pytest.raises(ValueError):
+        SCRIPT.zoom_range(0.0)
+
+
+def test_nothing_is_removed_when_the_previous_index_is_unreadable():
+    """load_index() returns [] for both "absent" and "could not read".
+
+    That collapse is deliberate and this pins the safe direction: an empty
+    previous index must produce an empty removal plan. The opposite -- an
+    unreadable index treated as "the bucket holds nothing I recognise" --
+    would delete a live pyramid on one transient GET failure.
+    """
+    assert SCRIPT.plan_removals([], ['live/history/15/1/2.png']) == []
+
+
+def test_tiles_the_new_pyramid_no_longer_covers_are_removed():
+    """A published tile outlives the mosaic that produced it.
+
+    The page paints a miss transparent, so ground dropped from the mosaic
+    keeps being served from the old render with nothing to say it is stale.
+    A static pyramid has no next pass to heal in, so the removal has to happen
+    across runs.
+    """
+    previous = ['live/history/15/1/1.png', 'live/history/15/1/2.png']
+    current = ['live/history/15/1/2.png', 'live/history/15/1/3.png']
+    assert SCRIPT.plan_removals(previous, current) == [
+        'live/history/15/1/1.png']
+
+
+def test_labels_default_to_the_basename_and_never_to_the_mtime():
+    """An export written the morning after a survey carries the wrong date.
+
+    Dating the layer from the file's mtime would publish that wrong date
+    confidently, over ground that was run the day before. The basename is
+    merely unhelpful, which is the better failure.
+    """
+    labels = SCRIPT.resolve_labels(
+        ['/data/Shoals Day1_1m_CUBE_ITRF2020.tif'], [])
+    assert labels == ['Shoals Day1_1m_CUBE_ITRF2020']
+
+
+def test_a_label_list_that_does_not_match_the_sources_is_refused():
+    """Labels are matched by POSITION, so a short list mislabels a day.
+
+    Silently zipping to the shorter list would publish the second day's
+    coverage under the first day's date, which is worse than not running.
+    """
+    with pytest.raises(ValueError):
+        SCRIPT.resolve_labels(['a.tif', 'b.tif'], ['2026-08-25'])
+    assert SCRIPT.resolve_labels(['a.tif', 'b.tif'],
+                                 ['2026-08-25', '2026-08-26']) == [
+        '2026-08-25', '2026-08-26']
+
+
+def test_the_manifest_carries_leaflet_bounds_not_geojson_order():
+    """[[south, west], [north, east]] -- the reverse of GeoJSON's [lon, lat].
+
+    Both orders are live on this page: state_renderer publishes GeoJSON and
+    the manifest feeds Leaflet. Getting this one backwards puts the survey in
+    the Indian Ocean, and nothing errors.
+    """
+    bounds = [[42.98, -70.71], [43.07, -70.60]]
+    manifest = SCRIPT.build_manifest(13, 17, 218, [
+        {'file': 'day1.tif', 'label': '2026-08-25'}], bounds, 1787832866.0)
+    (south, west), (north, east) = manifest['bounds']
+    assert south < north and west < east
+    assert -90 <= south <= 90 and -180 <= west <= 180
+
+
+def test_the_manifest_stays_small_enough_to_poll():
+    """Every viewer fetches this. The key index belongs in its own object.
+
+    Un-publishing needs the full list of published keys -- hundreds of
+    strings. Carried in the manifest, that is tens of kilobytes served to
+    every viewer every poll to communicate four numbers.
+    """
+    sources = [{'file': 'day{}.tif'.format(i), 'label': '2026-08-{:02d}'
+                .format(i)} for i in range(1, 15)]
+    manifest = SCRIPT.build_manifest(13, 17, 5000, sources,
+                                     [[42.9, -70.8], [43.1, -70.5]],
+                                     1787832866.0)
+    payload = json.dumps(manifest)
+    assert len(payload) < 4096, (
+        'the manifest is {} bytes; something bulky has been added to the '
+        'object every viewer polls'.format(len(payload)))
+    assert 'keys' not in manifest
+    assert manifest['labels'] == [s['label'] for s in sources]
+
+
+def test_the_tile_and_manifest_cache_headers_do_not_drift():
+    """A day that is over does not change; the manifest is how a new one lands.
+
+    Cache the manifest as hard as the tiles and a viewer with the page open
+    does not see tomorrow's survey until they force a reload. Cache the tiles
+    as briefly as the manifest and every pan re-fetches a pyramid that has not
+    changed since the day it was published.
+    """
+    assert 'max-age=86400' in SCRIPT.TILE_EXTRA_ARGS['CacheControl']
+    assert 'max-age=300' in SCRIPT.META_EXTRA_ARGS['CacheControl']
+    assert SCRIPT.TILE_EXTRA_ARGS['ContentType'] == 'image/png'
+
+
+def test_the_prefix_stays_inside_what_the_boat_credential_can_write():
+    """p11-renderer is scoped to s3:PutObject on live/* and nothing else.
+
+    Move this pyramid to a sibling top-level prefix and every run needs an
+    admin profile -- which is exactly the position refresh_chart_tiles.py is
+    in with tiles/, and the reason it cannot run under the boat's own
+    credential.
+    """
+    assert SCRIPT.PREFIX.startswith('live/')
+    assert SCRIPT.META_KEY.startswith('live/')
+    assert SCRIPT.INDEX_KEY.startswith('live/')

--- a/marine_web_view/test/test_page_layers.py
+++ b/marine_web_view/test/test_page_layers.py
@@ -910,3 +910,171 @@ def test_the_construction_pattern_tracks_the_pages_layer_classes():
         'a newly defined layer class is not discovered')
     assert re.search(_constructions(invented), 'x = new Sidescan({});'), (
         'a newly defined layer class would escape the addTo check')
+
+
+def test_the_history_layer_is_configured_from_its_manifest():
+    """The previous-days pyramid's zoom range is remote input like any other.
+
+    It drives minZoom/minNativeZoom on a second tile layer, so it carries the
+    identical browser-freeze hazard the coverage manifest does -- Leaflet lays
+    the viewport out in tiles of the native level whenever the map is below it.
+    The zooms must therefore reach the layer through `saneZoom`, and the pair
+    must be ordered: `min_zoom` above `max_zoom` describes a pyramid that
+    cannot exist, and Leaflet does not reject it.
+    """
+    code = _code(_page())
+    assert 'HISTORY_META' in code, 'the history manifest is not fetched'
+    assert re.search(r'saneZoom\(\s*meta\.min_zoom\s*\)', code), (
+        'the history min zoom does not come from the manifest via saneZoom')
+    assert re.search(r'saneZoom\(\s*meta\.max_zoom\s*\)', code), (
+        'the history max zoom does not come from the manifest via saneZoom')
+    assert re.search(r'lo\s*===\s*null\s*\|\|\s*hi\s*===\s*null\s*\|\|'
+                     r'\s*lo\s*>\s*hi', code), (
+        'a manifest whose zooms fail validation, or are inverted, still '
+        'configures the layer')
+    definition = re.search(r'function\s+buildHistory\s*\(', code)
+    assert definition, 'the page has no buildHistory()'
+    defined_at = definition.start() + definition.group(0).index('buildHistory')
+    calls = [m for m in re.finditer(r'\bbuildHistory\s*\(', code)
+             if m.start() != defined_at]
+    assert calls, (
+        'buildHistory() is defined but never called: the history layer is '
+        'never built and previous days never appear')
+    start, end = _function_span(code, 'pollHistory')
+    assert any(start <= call.start() < end for call in calls), (
+        'buildHistory() is never called from pollHistory()')
+
+
+def test_the_history_layer_does_not_share_the_live_coverage_pane():
+    """Finished days must not be drawn with the live layer's styling.
+
+    `.leaflet-coverage-pane` carries a drop shadow that means "this is the
+    live footprint". Fold history into that pane and the live outline is drawn
+    around ground the sonar left days ago -- which is the exact confusion this
+    layer was added to remove, since the bucket had days-old tiles standing in
+    live/coverage/ being drawn as if fresh.
+
+    It must also sit BELOW live coverage, or today's fresh line is buried
+    under yesterday's mosaic.
+    """
+    page = _page()
+    code = _code(page)
+    assert re.search(r"createPane\(\s*'history'\s*\)", code), (
+        'the history layer has no pane of its own')
+    assert re.search(r"pane:\s*'history'", code), (
+        'the history layer is not assigned to its own pane')
+    zindex = dict(re.findall(
+        r"getPane\(\s*'(\w+)'\s*\)\.style\.zIndex\s*=\s*(\d+)", code))
+    assert 'history' in zindex and 'coverage' in zindex, (
+        'one of the two panes no longer sets an explicit zIndex, so their '
+        'stacking is left to Leaflet and to declaration order')
+    assert int(zindex['history']) < int(zindex['coverage']), (
+        'the history pane ({}) is stacked at or above live coverage ({}): '
+        "today's coverage would be drawn under previous days".format(
+            zindex['history'], zindex['coverage']))
+
+
+def test_the_history_layer_carries_no_liveness_styling():
+    """A finished day cannot go stale, and must not be faded as if it could.
+
+    The coverage layer fades when its renderer stops, because what it shows
+    might be minutes out of date. History is a published artifact of a day
+    that is over: fading it would say something false, and the machinery that
+    does the fading has no manifest field here to drive it.
+    """
+    code = _code(_page())
+    start, end = _function_span(code, 'buildHistory')
+    body = code[start:end]
+    for forbidden in ('COVERAGE_STALE_OPACITY', 'setCoverageAlive',
+                      'coverageAlive'):
+        assert forbidden not in body, (
+            'buildHistory() reaches for {}: the history layer is being '
+            'given the live layer staleness behaviour'.format(forbidden))
+
+
+def test_a_missing_history_manifest_takes_the_layer_down():
+    """No history published is the ordinary state, and must read as such.
+
+    The failure that matters is the other one: leaving a previous manifest's
+    layer on the map after the manifest stops describing it. Those tiles may
+    have been un-published, in which case the layer is claiming days the
+    bucket no longer serves.
+    """
+    code = _code(_page())
+    start, end = _function_span(code, 'pollHistory')
+    body = code[start:end]
+    catch = body[body.index('catch'):]
+    assert re.search(r'map\.removeLayer\(\s*historyLayer\s*\)', catch), (
+        'an unreachable or malformed history manifest leaves the layer on '
+        'the map')
+    assert re.search(r'historyLayer\s*=\s*null', catch), (
+        'historyLayer is not cleared, so the next poll cannot rebuild it')
+    assert re.search(r'historyKey\s*=\s*null', catch), (
+        'historyKey survives the teardown, so a manifest that comes back '
+        'unchanged is treated as already built and the layer never returns')
+
+
+def test_the_history_toggle_cannot_desync_from_the_map():
+    """The checkbox and the map must agree after a rebuild, not just a click.
+
+    A new day republishes the manifest and rebuilds the layer. Add the rebuilt
+    layer without consulting the checkbox and a viewer who turned history off
+    finds it back the next morning, with the control still saying off -- the
+    same desync `syncAisLayer` exists to prevent on the AIS group.
+    """
+    code = _code(_page())
+    assert re.search(r"\$\('history'\)\.addEventListener\(\s*'change'", code), (
+        'the history checkbox is not wired to anything')
+    start, end = _function_span(code, 'buildHistory')
+    assert 'syncHistoryLayer()' in code[start:end], (
+        'buildHistory() does not re-apply the checkbox state, so a rebuilt '
+        'layer ignores it')
+    sync_start, sync_end = _function_span(code, 'syncHistoryLayer')
+    body = code[sync_start:sync_end]
+    assert re.search(r"\$\('history'\)\.checked", body), (
+        'syncHistoryLayer() does not read the checkbox')
+
+
+def test_history_labels_are_scrubbed_before_they_are_displayed():
+    """Manifest labels are free text that reaches the readout.
+
+    They are the operator's own words rather than a stranger's, so this is a
+    smaller worry than the AIS names -- but it is the same mechanism and the
+    same cheap fix: textContent closes off markup, and stripping bidi controls
+    closes off text that reorders what is printed around it.
+    """
+    code = _code(_page())
+    start, end = _function_span(code, 'historyLabels')
+    body = code[start:end]
+    assert 'u202A-' in body or 'u202a-' in body, (
+        'history labels are not stripped of bidi overrides')
+    assert re.search(r'\.slice\(\s*0\s*,\s*\d+\s*\)', body), (
+        'history labels are not length-capped before display')
+    assert re.search(r"\$\('hist'\)\.textContent", code), (
+        'the history readout is written through something other than '
+        'textContent')
+
+
+def test_no_top_level_statement_uses_the_dollar_helper_early():
+    """`const $` is declared late, and a top-level use above it is fatal.
+
+    Not a style point: `const` is not hoisted, so a top-level `$(...)` before
+    the declaration throws a ReferenceError at load -- which aborts the rest
+    of the script. No polls are scheduled, every readout stays on its em dash,
+    and the map comes up with the basemap and nothing else. It looks like a
+    network problem rather than a syntax-order one.
+
+    Every existing use of `$` is inside a function, where the declaration has
+    long since run by call time. This pins that a new one cannot quietly be
+    added at the top level above the declaration -- which is exactly how the
+    history toggle was first wired.
+    """
+    code = _code(_page())
+    declaration = re.search(r'^const \$ = ', code, re.M)
+    assert declaration, 'the page no longer declares the `$` helper'
+    early = [m.start() for m in re.finditer(r'^\$\(', code, re.M)
+             if m.start() < declaration.start()]
+    assert not early, (
+        'a top-level `$(...)` call appears at offset(s) {} , above the `$` '
+        'declaration at {}: that is a ReferenceError at load and the rest of '
+        'the script never runs'.format(early, declaration.start()))

--- a/marine_web_view/test/test_page_layers.py
+++ b/marine_web_view/test/test_page_layers.py
@@ -1182,3 +1182,45 @@ def test_the_coverage_outline_is_wired_end_to_end():
     assert re.search(r'\.leaflet-coverage-pane\s*\{[^}]*drop-shadow', page), (
         'the .leaflet-coverage-pane drop-shadow rule is gone -- coverage '
         'reverts to being the same colour as the seabed beneath it')
+
+
+def test_a_malformed_manifest_tears_the_layer_down_even_when_one_is_built():
+    """The teardown must not depend on whether a layer already exists.
+
+    `buildHistory()` returns false for BOTH a malformed manifest and the
+    ordinary "nothing changed" case, so its return alone cannot distinguish
+    them. Gating the throw on `historyLayer === null` meant a manifest that
+    went bad after a good one had loaded never reached the catch: the stale
+    layer stayed on the map claiming days that are no longer published, while
+    the readout was rewritten from the broken manifest. That is precisely what
+    the catch block's own comment says must not happen.
+    """
+    page = _page()
+    assert not re.search(r'!buildHistory\(meta\)\s*&&\s*historyLayer === null', page), (
+        'pollHistory still gates the malformed-manifest throw on there being '
+        'no existing layer -- a manifest that goes bad after a good one will '
+        'leave the stale layer on the map')
+    poll = page[page.index('async function pollHistory'):]
+    poll = poll[:poll.index('\n}')]
+    assert 'saneZoom' in poll, (
+        'pollHistory no longer validates the manifest zooms itself, so a '
+        'malformed manifest cannot reliably reach the teardown path')
+    assert "throw new Error('malformed manifest')" in poll, (
+        'pollHistory no longer throws on a malformed manifest')
+
+
+def test_the_history_readout_has_no_dangling_separator():
+    """`historyText()` must not emit "0 days · " with nothing after it.
+
+    `buildHistory()` gates on zooms only, never on labels, so a perfectly
+    valid manifest can reach the readout with no usable labels at all --
+    absent, empty, or emptied by the scrubber. The separator then introduces
+    nothing and reads as a formatting bug in exactly the error cases where the
+    readout most needs to be legible.
+    """
+    page = _page()
+    body = page[page.index('function historyText'):]
+    body = body[:body.index('\n}')]
+    assert re.search(r'if\s*\(\s*!labels\.length\s*\)\s*return\s+days\s*;', body), (
+        'historyText does not short-circuit on an empty label list, so it '
+        'still produces a trailing " · " separator with nothing after it')

--- a/marine_web_view/test/test_page_layers.py
+++ b/marine_web_view/test/test_page_layers.py
@@ -602,7 +602,7 @@ def test_the_coverage_layer_is_configured_from_the_manifest():
     # built. The test passed solely because the definition's parameter happens
     # to be spelled `zoom`.
     defined_at = definition.start() + definition.group(0).index('buildCoverage')
-    calls = [m for m in re.finditer(r'\bbuildCoverage\s*\(\s*([^)]*?)\s*\)',
+    calls = [m for m in re.finditer(r'\bbuildCoverage\s*\(\s*([^,)]*?)\s*[,)]',
                                     code)
              if m.start() != defined_at]
     assert calls, (
@@ -614,8 +614,8 @@ def test_the_coverage_layer_is_configured_from_the_manifest():
         'not built from the manifest the poll just read')
     for call in calls:
         assert call.group(1) == 'zoom', (
-            'buildCoverage is called with {!r}: the layer must be built from '
-            'the validated zoom, not from the raw manifest field'
+            'buildCoverage first argument is {!r}: the layer must be built '
+            'from the validated zoom, not from the raw manifest field'
             .format(call.group(1)))
     assert re.search(r'(?:const|let|var)\s+zoom\s*=\s*saneZoom\('
                      r'\s*meta\.zoom\s*\)', code), (
@@ -673,7 +673,8 @@ def test_the_coverage_refresh_is_gated_on_the_change_signal():
     start, end = _function_span(page, 'pollCoverage')
     body = page[start:end]
 
-    gate = re.search(r'if\s*\(([^)]*)\)\s*refreshCoverage\s*\(\s*\)', body)
+    gate = re.search(r'if\s*\(([^)]*)\)\s*refreshCoverage\s*\([^)]*\)',
+                     body)
     assert gate, (
         'pollCoverage() does not call refreshCoverage() under a guard: the '
         'tile layer either never refreshes or refreshes unconditionally')
@@ -1078,3 +1079,72 @@ def test_no_top_level_statement_uses_the_dollar_helper_early():
         'a top-level `$(...)` call appears at offset(s) {} , above the `$` '
         'declaration at {}: that is a ReferenceError at load and the rest of '
         'the script never runs'.format(early, declaration.start()))
+
+
+def test_the_coverage_tile_url_is_versioned_so_a_redraw_refetches():
+    """A redraw that reuses the URL fetches nothing, and the map freezes.
+
+    Leaflet's redraw() drops every tile element and creates new ones with the
+    same src. Chrome answers those from the document's in-memory resource
+    cache without revalidating: measured against tiles carrying max-age=10,
+    across seven redraws spanning 36 s of real time, an existing tile was
+    requested exactly ONCE, while uncacheable 404s in the same layout were
+    re-requested every pass. The display then sits on the frame it first
+    loaded until the operator reloads the page by hand -- which is what the
+    boat reported, twice.
+
+    The first fix lowered cache_control below render_interval on the
+    assumption the browser would miss cache once the tile expired. It cannot
+    work: the browser never asks. Only a changed URL forces the fetch, so the
+    URL must carry a version -- and this pins it, because the failure is
+    invisible in every static reading of the page.
+    """
+    code = _code(_page())
+    assert re.search(r"COVERAGE_DIR\s*\+\s*'\{z\}/\{x\}/\{y\}\.png\?v=\{v\}'",
+                     code), (
+        'the coverage tile URL carries no version: every redraw requests a '
+        'URL the browser already holds, and the layer freezes until reload')
+    start, end = _function_span(code, 'buildCoverage')
+    assert re.search(r'\bv:\s*version\b', code[start:end]), (
+        'the layer is built without seeding its URL version')
+
+
+def test_the_coverage_version_moves_before_the_redraw_not_after():
+    """redraw() reads the URL as it builds each tile.
+
+    Set the version afterwards and every pass renders the PREVIOUS version's
+    tiles -- a permanently one-pass-stale display, which looks enough like
+    working to survive review.
+    """
+    code = _code(_page())
+    start, end = _function_span(code, 'refreshCoverage')
+    body = code[start:end]
+    assign = body.find('options.v = version')
+    redraw = body.find('.redraw(')
+    assert assign != -1, 'refreshCoverage() never updates the URL version'
+    assert redraw != -1, 'refreshCoverage() no longer redraws'
+    assert assign < redraw, (
+        'the version is applied after redraw(), so each pass draws the '
+        'previous version of every tile')
+
+
+def test_the_coverage_version_is_shared_by_every_viewer():
+    """A per-viewer cache-buster would move the load onto the origin.
+
+    The version must be the renderer's own counter, identical for everyone,
+    so CloudFront still serves one object to all viewers. `Date.now()` or
+    `Math.random()` would work in the browser and quietly turn every tile
+    request into an origin fetch, per viewer, forever -- the cost the manifest
+    poll deliberately avoids by NOT cache-busting.
+    """
+    code = _code(_page())
+    start, end = _function_span(code, 'pollCoverage')
+    body = code[start:end]
+    assert re.search(r'const\s+version\s*=\s*rendered\s*===\s*null\s*\?\s*0'
+                     r'\s*:\s*rendered', body), (
+        'the tile version no longer comes from the validated manifest counter')
+    for forbidden in ('Date.now()', 'Math.random()'):
+        assert forbidden not in body.split('const version')[1][:400], (
+            'the tile version is derived from {}: that is a per-viewer '
+            'cache-buster and every tile GET becomes an origin fetch'
+            .format(forbidden))

--- a/marine_web_view/web/index.html
+++ b/marine_web_view/web/index.html
@@ -137,12 +137,14 @@
     <dt>Heading</dt><dd id="hdg">—</dd>
     <dt>Fix age</dt><dd id="age">—</dd>
     <dt>Coverage</dt><dd id="cov">—</dd>
+    <dt>History</dt><dd id="hist">—</dd>
     <dt>AIS</dt><dd id="ais-age">—</dd>
   </dl>
   <div id="status"><span id="dot"></span><span id="msg">connecting…</span></div>
   <div id="details">
   <label><input type="checkbox" id="follow" checked> follow boat</label>
   <label><input type="checkbox" id="ais" checked> AIS traffic</label>
+  <label><input type="checkbox" id="history" checked> previous days</label>
   <div id="legend"><h2>Depth</h2></div>
   <div id="credit">
     Operated by the Center for Coastal and Ocean Mapping / Joint Hydrographic
@@ -222,6 +224,16 @@ map.createPane('coverage');
 // Same stacking the layer's own zIndex option used to set, moved up to the pane
 // so the pane (and its outline) sits above imagery and hillshade as one unit.
 map.getPane('coverage').style.zIndex = 350;
+
+// Previous days get their own pane BELOW live coverage, and separate from it
+// for two reasons. Stacking: today's coverage must draw over the ground it
+// re-runs, not under it. And the outline: `.leaflet-coverage-pane`'s drop
+// shadow means "this is the live footprint", so folding finished days into
+// that pane would put the live outline around ground the sonar left days ago.
+// This pane deliberately carries no filter of its own -- the history layer is
+// meant to recede.
+map.createPane('history');
+map.getPane('history').style.zIndex = 340;
 
 // Basemap: Esri World Imagery -- genuinely cached. NOTE {z}/{y}/{x} (ArcGIS
 // order), reversed from the usual XYZ, and the tiles are JPEG.
@@ -654,6 +666,145 @@ async function pollCoverage() {
   }
 }
 
+// ---- Previous days' coverage ---------------------------------------------
+//
+// Published by scripts/publish_history_tiles.py from the finished exports of
+// days already surveyed, into its own prefix and its own pane.
+//
+// A separate layer rather than more tiles under live/coverage/, because the
+// two carry different claims. Live coverage means "the sonar is on this
+// ground now" and the page spends real machinery saying so -- a heartbeat
+// manifest, a staleness fade, a footprint outline. A finished day makes no
+// such claim: it does not change, it cannot go stale, and there is nothing to
+// fade. Drawing it through the live layer's styling would attach the live
+// claim to it, which is the failure this layer exists to fix -- the bucket
+// had days-old tiles standing in live/coverage/, drawn as if fresh.
+//
+// It carries the export's own rainbow ramp rather than this page's pinned
+// 0-40 m blue-green one, and cannot be recoloured onto it: the exports have
+// hillshade baked into the RGB, so colour does not invert back to depth. The
+// publisher mutes them toward a warm neutral instead, and the divergence
+// becomes the signal -- old is desaturated and warm, live is saturated and
+// cool. Two palettes that cannot be read as one scale, which is also why the
+// depth legend is NOT extended to cover this layer.
+const HISTORY_DIR  = 'live/history/';
+const HISTORY_META = HISTORY_DIR + 'meta.json';
+// Slow, and it is not a liveness poll: the manifest changes when a day's
+// export is published, at most once a day. This exists so a viewer who left
+// the page open overnight picks up yesterday without a reload.
+const HISTORY_MS = 300000;                    // 5 minutes
+const HISTORY_MAX_Z = 22;                     // matches the map's own maxZoom
+const HISTORY_OPACITY = 0.8;                  // fallback; the manifest sets it
+// The same transparent pixel the coverage layer uses. A miss is the normal
+// case for both -- the publisher writes no tile for ground nobody surveyed --
+// so a miss must paint nothing rather than a broken-image icon.
+const HISTORY_BLANK = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+let historyLayer = null, historyKey = null;
+
+// How much of the manifest is trusted, and why each check is here:
+//
+// The zooms configure minZoom/minNativeZoom, which is the SAME browser-freeze
+// bound buildCoverage() documents -- below its native zoom Leaflet lays the
+// whole viewport out in tiles of that level, 4^n of them. So they get the
+// identical Number.isInteger 0..22 treatment through saneZoom(), plus an
+// ordering check the coverage manifest does not need, carrying one zoom.
+//
+// The labels are the operator's own text from the command line, rendered into
+// the readout. They go in through textContent, so markup is already inert, but
+// they are still capped and stripped of control and bidi characters for the
+// reason ais_renderer scrubs contact names: a bidi override reorders the text
+// AROUND it, so a label can be dressed to read as something it is not.
+function historyLabels(meta) {
+  if (!Array.isArray(meta.labels)) return [];
+  return meta.labels
+    .filter(x => typeof x === 'string')
+    .slice(0, 12)
+    .map(x => x.replace(
+        /[\u0000-\u001F\u007F-\u009F\u200E\u200F\u202A-\u202E\u2066-\u2069]/g,
+        '').slice(0, 24))
+    .filter(x => x.length);
+}
+
+// Returns true when the layer was actually rebuilt. A rebuild tears the layer
+// down and re-requests every visible tile, which is right when a new day has
+// been published and pure churn on the other 287 polls of the day -- so the
+// pyramid's shape, not the manifest's stamp, is what decides.
+function buildHistory(meta) {
+  const lo = saneZoom(meta.min_zoom), hi = saneZoom(meta.max_zoom);
+  if (lo === null || hi === null || lo > hi) return false;
+  const opacity = (typeof meta.opacity === 'number' && meta.opacity > 0
+                   && meta.opacity <= 1) ? meta.opacity : HISTORY_OPACITY;
+  const key = [lo, hi, opacity, meta.tiles | 0,
+               historyLabels(meta).join('|')].join(',');
+  if (key === historyKey) return false;
+  historyKey = key;
+  if (historyLayer) { map.removeLayer(historyLayer); historyLayer = null; }
+  historyLayer = new L.TileLayer(HISTORY_DIR + '{z}/{x}/{y}.png', {
+    // minZoom, not just minNativeZoom -- see buildCoverage() for what the
+    // difference costs. The pyramid is rendered down to its own floor, so
+    // below that the layer is hidden rather than upscaled from nothing.
+    minZoom: lo,
+    maxZoom: HISTORY_MAX_Z,
+    minNativeZoom: lo, maxNativeZoom: hi,
+    opacity: opacity,
+    pane: 'history',
+    errorTileUrl: HISTORY_BLANK,
+    attribution: 'Previous days: MBES, CCOM/JHC'
+  }).addTo(map);
+  // Added unconditionally, then removed again by syncHistoryLayer() if the
+  // box is unchecked. Reaching the map at the construction site is what
+  // test_page_layers.py can actually verify -- a layer reached only through
+  // a toggle is indistinguishable from one that is never reached at all,
+  // which is the #341 failure that test exists for. The cost is that a
+  // viewer who has turned the layer OFF gets one frame of aborted tile
+  // requests when a new day is published; that is once a day, against a
+  // guard that is checked on every commit.
+  syncHistoryLayer();
+  return true;
+}
+
+// The checkbox and the map are kept in step through one function, called on
+// every change AND after every rebuild: a layer replaced while the box was
+// unchecked would otherwise come back visible, with the control saying the
+// opposite of what the map is doing.
+function syncHistoryLayer() {
+  if (!historyLayer) return;
+  if ($('history').checked) map.addLayer(historyLayer);
+  else map.removeLayer(historyLayer);
+}
+
+function historyText(meta) {
+  const labels = historyLabels(meta);
+  const days = labels.length + (labels.length === 1 ? ' day' : ' days');
+  const joined = labels.join(', ');
+  // The readout is narrow and a label is free text; past a line's worth, the
+  // count is the part worth keeping.
+  return joined.length <= 34 ? days + ' · ' + joined : days;
+}
+
+async function pollHistory() {
+  try {
+    // `default`, not `no-store`: unlike the coverage manifest this is not a
+    // heartbeat, so being answered from the browser's own cache within its
+    // 5-minute max-age costs nothing and keeps the request off the origin.
+    const r = await fetch(HISTORY_META, { cache: 'default' });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const meta = await r.json();
+    if (!buildHistory(meta) && historyLayer === null) {
+      throw new Error('malformed manifest');
+    }
+    $('hist').textContent = historyText(meta);
+  } catch (e) {
+    // No history published for this survey is the ORDINARY state on day one,
+    // not a fault: nothing is drawn and the readout says so plainly. What it
+    // must not do is leave a previous manifest's layer on the map claiming
+    // days that are no longer published.
+    if (historyLayer) { map.removeLayer(historyLayer); historyLayer = null; }
+    historyKey = null;
+    $('hist').textContent = 'none published';
+  }
+}
+
 // Legend: continuous bar built from the same RAMP, so it cannot drift from
 // what is rendered. Top = surface, bottom = MAX_DEPTH.
 (function () {
@@ -1065,6 +1216,16 @@ function syncAisLayer() {
 $('ais').addEventListener('change', syncAisLayer);
 syncAisLayer();
 
+// Wired HERE, beside the AIS toggle, and not down in the history section --
+// `$` is defined further down the page than that section is, and a top-level
+// `$(...)` call up there is a ReferenceError at load that takes the whole
+// script with it: no polls scheduled, every readout stuck on an em dash, and
+// a map with nothing but the basemap on it. Every other use of `$` is inside
+// a function, so only a top-level one is exposed to the ordering.
+// syncHistoryLayer() is not called here: the layer does not exist until the
+// first manifest arrives, and buildHistory() applies the checkbox itself.
+$('history').addEventListener('change', syncHistoryLayer);
+
 async function poll() {
   try {
     const r = await fetch(SRC, { cache:'default' });   // no cache-buster: let
@@ -1077,10 +1238,12 @@ poll();
 pollTrack();
 pollCoverage();
 pollAis();
+pollHistory();
 setInterval(poll, POLL_MS);
 setInterval(pollTrack, TRACK_MS);
 setInterval(pollCoverage, COVERAGE_MS);
 setInterval(pollAis, AIS_MS);
+setInterval(pollHistory, HISTORY_MS);
 setInterval(updateAge, 1000);
 
 // Start collapsed on a phone: the map is the point, the readout is secondary.

--- a/marine_web_view/web/index.html
+++ b/marine_web_view/web/index.html
@@ -527,11 +527,33 @@ function setCoverageAlive(alive) {
 
 // Returns true when the layer was actually (re)built, so the caller knows the
 // tiles have just been requested and does not immediately ask again.
-function buildCoverage(zoom) {
+function buildCoverage(zoom, version) {
   if (coverageZoom === zoom) return false;
   if (coverageLayer) { map.removeLayer(coverageLayer); coverageLayer = null; }
   coverageZoom = zoom;
-  coverageLayer = new L.TileLayer(COVERAGE_DIR + '{z}/{x}/{y}.png', {
+  coverageLayer = new L.TileLayer(COVERAGE_DIR + '{z}/{x}/{y}.png?v={v}', {
+    // The tile URL carries the renderer's published-tile counter, and this is
+    // what makes a redraw actually fetch anything.
+    //
+    // Leaflet's redraw() drops every tile element and builds new ones with
+    // the SAME src. Chrome answers those from the document's in-memory
+    // resource cache without revalidating -- measured: across seven redraws
+    // spanning 36 s of real time against tiles carrying max-age=10, an
+    // existing tile was requested exactly ONCE, while uncacheable 404s in the
+    // same layout were re-requested every pass. So the tile the page shows is
+    // frozen at whatever it first loaded, for the life of the document, and
+    // the only cure is the manual browser refresh the boat kept reporting.
+    //
+    // Lowering cache_control below render_interval was the earlier attempt at
+    // this and could not have worked: the browser never asks, so no max-age
+    // short of no-store changes the outcome.
+    //
+    // `v` moves only when the renderer publishes -- the same value for every
+    // viewer, so this is not the per-viewer cache busting the manifest fetch
+    // rightly avoids. CloudFront's cache policy here (Managed-CachingOptimized)
+    // keeps query strings OUT of the cache key, so the edge still serves one
+    // object to everyone and the version costs nothing there.
+    v: version,
     // minZoom, NOT just minNativeZoom. Leaflet's _clampZoom returns
     // minNativeZoom whenever the map is below it, and then lays the whole
     // viewport out in tiles OF THAT ZOOM: at map zoom 10 against a native 15
@@ -581,8 +603,12 @@ function buildCoverage(zoom) {
 // the requests, and the short max-age is what decides whether the browser can
 // answer them from its own cache or has to go back to CloudFront. Without a
 // redraw the browser is simply never asked, and the max-age is inert.
-function refreshCoverage() {
+function refreshCoverage(version) {
   if (!coverageLayer) return;
+  // Before the redraw, not after: redraw() reads the URL as it builds each
+  // tile, so a version applied afterwards would take effect one pass late --
+  // which is the same one-pass-stale display, just harder to see.
+  coverageLayer.options.v = version;
   // redraw() does NOT honour the layer's own minZoom. Leaflet applies minZoom
   // only in _setView; redraw() goes through _clampZoom, which consults
   // min/maxNativeZoom alone. So redrawing a layer that minZoom is currently
@@ -640,7 +666,12 @@ async function pollCoverage() {
       // layer's zoom bounds and its liveness clock from nonsense.
       throw new Error('malformed manifest');
     }
-    const rebuilt = buildCoverage(zoom);
+    // The version the tile URLs carry. `rendered` is already validated by
+    // saneCount; a manifest that fails it leaves the version pinned at 0,
+    // which is the pre-versioning behaviour rather than a URL reading
+    // `?v=null` that would never match the object the CDN holds.
+    const version = rendered === null ? 0 : rendered;
+    const rebuilt = buildCoverage(zoom, version);
     // Refresh on "the tiles CHANGED", never on "a pass happened". `stamp` is
     // rewritten every pass whether or not anything was rendered, so gating on
     // it meant a docked boat with the sonar off drove a full teardown and
@@ -651,7 +682,7 @@ async function pollCoverage() {
     // moves it backwards and that is still news. A rebuild has just requested
     // every tile anyway.
     const advanced = rendered !== null && rendered !== coverageRendered;
-    if (!rebuilt && advanced) refreshCoverage();
+    if (!rebuilt && advanced) refreshCoverage(version);
     coverageRendered = rendered;
     coverageStamp = stamp;
     const age = Date.now()/1000 - stamp;

--- a/marine_web_view/web/index.html
+++ b/marine_web_view/web/index.html
@@ -809,7 +809,11 @@ function historyText(meta) {
   const days = labels.length + (labels.length === 1 ? ' day' : ' days');
   const joined = labels.join(', ');
   // The readout is narrow and a label is free text; past a line's worth, the
-  // count is the part worth keeping.
+  // count is the part worth keeping. With no usable labels at all -- absent,
+  // empty, or emptied by scrubbing -- the separator has nothing to introduce,
+  // and buildHistory() gates on zooms only so a valid manifest can reach here
+  // with none.
+  if (!labels.length) return days;
   return joined.length <= 34 ? days + ' · ' + joined : days;
 }
 
@@ -821,9 +825,19 @@ async function pollHistory() {
     const r = await fetch(HISTORY_META, { cache: 'default' });
     if (!r.ok) throw new Error('HTTP ' + r.status);
     const meta = await r.json();
-    if (!buildHistory(meta) && historyLayer === null) {
+    // Validate BEFORE consulting buildHistory's return, and independently of
+    // whether a layer already exists. buildHistory() returns false both for a
+    // malformed manifest and for the ordinary "nothing changed, no rebuild
+    // needed" case, so its return alone cannot distinguish them -- and gating
+    // the throw on `historyLayer === null` meant a manifest that went bad
+    // AFTER a good one loaded left the old layer on the map claiming days that
+    // are no longer published, which is exactly what the catch below exists to
+    // prevent.
+    if (saneZoom(meta.min_zoom) === null || saneZoom(meta.max_zoom) === null ||
+        saneZoom(meta.min_zoom) > saneZoom(meta.max_zoom)) {
       throw new Error('malformed manifest');
     }
+    buildHistory(meta);
     $('hist').textContent = historyText(meta);
   } catch (e) {
     // No history published for this survey is the ORDINARY state on day one,


### PR DESCRIPTION
Imports the 2026-08-26/27 field commits from gitcloud. Part of
[rolker/unh_marine_autonomy#362](https://github.com/rolker/unh_marine_autonomy/issues/362); produced
during the wrap-up of deployment
[rolker/unh_echoboats_project11#467](https://github.com/rolker/unh_echoboats_project11/issues/467).

Branched directly from `gitcloud/jazzy` so the original field SHAs are preserved — origin and the
field remote stay reconcilable without a force-push. Not diverged; this is a fast-forward.

## What's in it

Seven commits: the previously-surveyed-days tile pyramid (`publish_history_tiles.py`, 813 lines new,
with 248 lines of new tests), the launch fixes that made `ais_renderer` startable at all, a GDAL
spatial-reference leak fix, coverage-tile URL versioning so a redraw actually refetches, and one
field workaround.

## Reviewer attention: `1ffc459` is a declared workaround

The commit says so itself — *"NOT the intended QoS. Revert to TRANSIENT_LOCAL once the relay is
fixed."* It drops the `coverage_catalog` subscription to VOLATILE because udp_bridge republishes the
catalog VOLATILE on the operator side while `cube_bathymetry` publishes it `transient_local`
(`cube_bathymetry_node.cpp:515`), and the two cannot match. Without it this renderer received no
catalog across 204 render passes and the public page sat nearly empty mid-survey.

The cost is stated plainly in the commit: no late-join latching, so the renderer sees nothing until
the producer next publishes — ~6 s during an active survey, unbounded when the producer is down.

**Where the real fix belongs is unresolved.** Asked during the #467 wrap-up interview, the operator
declined to adjudicate: *"I don't have an opinion on 1, I'd have to delve deeper into what was
happening."* `camp` carries the mirror-image change
([rolker/camp#219](https://github.com/rolker/camp/issues/219)), so the two need to be reverted
together whenever the relay is fixed.

## Test plan

- New: `test_history_tiles.py` (248 lines) covers the history-pyramid publishing path.
- Extended: `test_page_layers.py` (+246 lines) covers the page-layer compositing.
- Field-verified on pandy over the 2026-08-26 and 2026-08-27 Appledore deployments; the catalog
  reconciler was observed draining live (*"catalog: 71 entries -> request 71, prune 0"*).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
